### PR TITLE
Add breadcrumb helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,11 @@ And then execute:
 ## Usage
 
 TBD.
+
+### Documentation
+
+See [RubyDoc](http://www.rubydoc.info/gems/govuk_navigation_helpers) for some limited documentation.
+
+To run a Yard server locally to preview documentation, run:
+
+    $ bundle exec yard server --reload

--- a/Rakefile
+++ b/Rakefile
@@ -4,10 +4,15 @@ require "gem_publisher"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task default: [:spec]
+task default: [:spec, :lint]
 
 desc "Publish gem to RubyGems"
 task :publish_gem do |_t|
   published_gem = GemPublisher.publish_if_updated("govuk_navigation_helpers.gemspec", :rubygems)
   puts "Published #{published_gem}" if published_gem
+end
+
+desc "Run govuk-lint with similar params to CI"
+task "lint" do
+  sh "bundle exec govuk-lint-ruby --format clang"
 end

--- a/govuk_navigation_helpers.gemspec
+++ b/govuk_navigation_helpers.gemspec
@@ -23,6 +23,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "gem_publisher", "~> 1.5.0"
   spec.add_development_dependency "govuk-lint", "~> 1.2.1"
+  spec.add_development_dependency "pry-byebug", "~> 3.4"
+  spec.add_development_dependency "yard", "~> 0.8"
+  spec.add_development_dependency "govuk_schemas", "~> 0.1"
 
   spec.required_ruby_version = ">= 2.3.1"
 end

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -42,6 +42,15 @@ bundle exec govuk-lint-ruby \
   --format html --out rubocop-${GIT_COMMIT}.html \
   --format clang
 
+  # Clone govuk-content-schemas depedency for contract tests
+  rm -rf /tmp/govuk-content-schemas
+  git clone git@github.com:alphagov/govuk-content-schemas.git /tmp/govuk-content-schemas
+  (
+    cd /tmp/govuk-content-schemas
+    git checkout ${SCHEMA_GIT_COMMIT:-"master"}
+  )
+  export GOVUK_CONTENT_SCHEMAS_PATH=/tmp/govuk-content-schemas
+
 # Bundle and run tests against multiple ruby versions
 for version in 2.3.1; do
   rm -f Gemfile.lock

--- a/lib/govuk_navigation_helpers.rb
+++ b/lib/govuk_navigation_helpers.rb
@@ -1,5 +1,35 @@
 require "govuk_navigation_helpers/version"
 
 module GovukNavigationHelpers
-  # Your code goes here...
+  class NavigationHelper
+    def initialize(content_item)
+      @content_item = content_item
+    end
+
+    # Generate a breacrumb trail
+    #
+    # @return [Array<Hash>] Each item is a hash containing `:title` and `:url` for one link in the breadcrumb
+    def breadcrumbs
+      direct_parent = content_item.dig("links", "parent", 0)
+
+      ordered_parents = []
+
+      while direct_parent
+        ordered_parents << {
+          title: direct_parent["title"],
+          url: direct_parent["base_path"],
+        }
+
+        direct_parent = direct_parent.dig("links", "parent", 0)
+      end
+
+      ordered_parents << { title: "Home", url: "/" }
+
+      ordered_parents.reverse
+    end
+
+  private
+
+    attr_reader :content_item
+  end
 end

--- a/spec/govuk_navigation_helps_spec.rb
+++ b/spec/govuk_navigation_helps_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+require 'govuk_navigation_helpers'
+require 'govuk_schemas'
+
+RSpec.describe GovukNavigationHelpers::NavigationHelper do
+  describe "#breadcrumbs" do
+    it "can handle any valid content item" do
+      generator = GovukSchemas::RandomExample.for_schema("placeholder", schema_type: "frontend")
+
+      50.times do
+        expect {
+          described_class.new(generator.payload).breadcrumbs
+        }.to_not raise_error
+      end
+    end
+
+    it "returns the root when parent is not specified" do
+      content_item = { "links" => {} }
+      breadcrumbs = breadcrumbs_for(content_item)
+
+      expect(breadcrumbs).to eq(
+        [
+          { title: "Home", url: "/" },
+        ]
+      )
+    end
+
+    it "returns the root when parent is empty" do
+      content_item = content_item_with_parents([])
+      breadcrumbs = breadcrumbs_for(content_item)
+
+      expect(breadcrumbs).to eq(
+        [
+          { title: "Home", url: "/" },
+        ]
+      )
+    end
+
+    it "places parent under the root when there is a parent" do
+      parent = {
+        "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+        "locale" => "en",
+        "title" => "A-parent",
+        "base_path" => "/a-parent",
+      }
+
+      content_item = content_item_with_parents([parent])
+      breadcrumbs = breadcrumbs_for(content_item)
+
+      expect(breadcrumbs).to eq(
+        [
+          { title: "Home", url: "/" },
+          { title: "A-parent", url: "/a-parent" }
+        ]
+      )
+    end
+
+    it "includes grandparent when available" do
+      grandparent = {
+        "title" => "Another-parent",
+        "base_path" => "/another-parent",
+        "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+        "locale" => "en",
+      }
+
+      parent = {
+        "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+        "locale" => "en",
+        "title" => "A-parent",
+        "base_path" => "/a-parent",
+        "links" => {
+          "parent" => [grandparent]
+        }
+      }
+
+      content_item = content_item_with_parents([parent])
+      breadcrumbs = breadcrumbs_for(content_item)
+
+      expect(breadcrumbs).to eq(
+        [
+          { title: "Home", url: "/" },
+          { title: "Another-parent", url: "/another-parent" },
+          { title: "A-parent", url: "/a-parent" }
+        ]
+      )
+    end
+  end
+
+  def content_item_with_parents(parents)
+    {
+      "links" => { "parent" => parents }
+    }
+  end
+
+  def breadcrumbs_for(content_item)
+    generator = GovukSchemas::RandomExample.for_schema("placeholder", schema_type: "frontend")
+    fully_valid_content_item = generator.merge_and_validate(content_item)
+    described_class.new(fully_valid_content_item).breadcrumbs
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,9 @@
 # users commonly want.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require 'pry-byebug'
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
Implementation is taken from government-frontend, which
doesn't place any restrictions on breadcrumb length.
See https://github.com/alphagov/government-frontend/pull/163

One change in behaviour is this gem always returns a breadcrumb:
if a parent link is not available, it will just show a Home link.

In most cases we want to show a consistent breadcrumb component
on all pages, and we don't know of any cases where we wouldn't
want to root this at the homepage.  If there is any reason not
to show a breacrumb, then the frontend app should avoid calling
this.