### PR TITLE
Move breadcrumbs code into own class

### DIFF
--- a/lib/govuk_navigation_helpers.rb
+++ b/lib/govuk_navigation_helpers.rb
@@ -1,4 +1,5 @@
 require "govuk_navigation_helpers/version"
+require "govuk_navigation_helpers/breadcrumbs"
 
 module GovukNavigationHelpers
   class NavigationHelper
@@ -10,22 +11,7 @@ module GovukNavigationHelpers
     #
     # @return [Array<Hash>] Each item is a hash containing `:title` and `:url` for one link in the breadcrumb
     def breadcrumbs
-      direct_parent = content_item.dig("links", "parent", 0)
-
-      ordered_parents = []
-
-      while direct_parent
-        ordered_parents << {
-          title: direct_parent["title"],
-          url: direct_parent["base_path"],
-        }
-
-        direct_parent = direct_parent.dig("links", "parent", 0)
-      end
-
-      ordered_parents << { title: "Home", url: "/" }
-
-      ordered_parents.reverse
+      Breadcrumbs.new(content_item).breadcrumbs
     end
 
   private

--- a/lib/govuk_navigation_helpers/breadcrumbs.rb
+++ b/lib/govuk_navigation_helpers/breadcrumbs.rb
@@ -1,0 +1,30 @@
+module GovukNavigationHelpers
+  class Breadcrumbs
+    def initialize(content_item)
+      @content_item = content_item
+    end
+
+    def breadcrumbs
+      direct_parent = content_item.dig("links", "parent", 0)
+
+      ordered_parents = []
+
+      while direct_parent
+        ordered_parents << {
+          title: direct_parent["title"],
+          url: direct_parent["base_path"],
+        }
+
+        direct_parent = direct_parent.dig("links", "parent", 0)
+      end
+
+      ordered_parents << { title: "Home", url: "/" }
+
+      ordered_parents.reverse
+    end
+
+  private
+
+    attr_reader :content_item
+  end
+end

--- a/spec/breadcrumbs_spec.rb
+++ b/spec/breadcrumbs_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'govuk_navigation_helpers'
 require 'govuk_schemas'
 
-RSpec.describe GovukNavigationHelpers::NavigationHelper do
+RSpec.describe GovukNavigationHelpers::Breadcrumbs do
   describe "#breadcrumbs" do
     it "can handle any valid content item" do
       generator = GovukSchemas::RandomExample.for_schema("placeholder", schema_type: "frontend")
@@ -95,6 +95,9 @@ RSpec.describe GovukNavigationHelpers::NavigationHelper do
   def breadcrumbs_for(content_item)
     generator = GovukSchemas::RandomExample.for_schema("placeholder", schema_type: "frontend")
     fully_valid_content_item = generator.merge_and_validate(content_item)
-    described_class.new(fully_valid_content_item).breadcrumbs
+
+    # Use the main class instead of GovukNavigationHelpers::Breadcrumbs, so that
+    # we're testing both at the same time.
+    GovukNavigationHelpers::NavigationHelper.new(fully_valid_content_item).breadcrumbs
   end
 end


### PR DESCRIPTION
This makes it easier to add a new component without the main class growing too large.