### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+* Functionality to generate data for the breadcrumb component

--- a/lib/govuk_navigation_helpers/version.rb
+++ b/lib/govuk_navigation_helpers/version.rb
@@ -1,3 +1,3 @@
 module GovukNavigationHelpers
-  VERSION = "0.0.1".freeze
+  VERSION = "1.0.0".freeze
 end


### PR DESCRIPTION
Since we're going to be using it in production, we need to release version 1.0.0 to indicate we'll follow semantic versioning from now on (semantic versioning doesn't apply < 1).