### PR TITLE
Add URL for “more” link to related items helper

### DIFF
--- a/lib/govuk_navigation_helpers/related_items.rb
+++ b/lib/govuk_navigation_helpers/related_items.rb
@@ -42,7 +42,7 @@ module GovukNavigationHelpers
         }
       end
 
-      { title: content_item.parent.title, items: items }
+      { title: content_item.parent.title, url: content_item.parent.base_path, items: items }
     end
 
     def with_grandparent_in_common_section
@@ -55,7 +55,7 @@ module GovukNavigationHelpers
         }
       end
 
-      { title: content_item.parent.parent.title, items: items }
+      { title: content_item.parent.parent.title, url: content_item.parent.parent.base_path, items: items }
     end
 
     def elsewhere_on_govuk_section

--- a/spec/related_items_spec.rb
+++ b/spec/related_items_spec.rb
@@ -119,6 +119,7 @@ RSpec.describe GovukNavigationHelpers::RelatedItems do
         sections: [
           {
             title: "Foo's parent",
+            url: "/foo-parent",
             items: [
               { title: "Foo", url: "/bar" },
             ]
@@ -186,6 +187,7 @@ RSpec.describe GovukNavigationHelpers::RelatedItems do
         sections: [
           {
             title: "Foo's grandparent",
+            url: "/foo-grand-parent",
             items: [
               { title: "Foo", url: "/bar" },
             ]


### PR DESCRIPTION
This commit adds the URL of the parent/grandparent to the data returned by the related items helper. The presence of the URL will trigger the related items component to render a “more” link as the last link of the parent/grandparent section.