### PR TITLE
Make the breadcrumbs helper return a hash

### DIFF
--- a/lib/govuk_navigation_helpers/breadcrumbs.rb
+++ b/lib/govuk_navigation_helpers/breadcrumbs.rb
@@ -20,7 +20,9 @@ module GovukNavigationHelpers
 
       ordered_parents << { title: "Home", url: "/" }
 
-      ordered_parents.reverse
+      {
+        breadcrumbs: ordered_parents.reverse
+      }
     end
 
   private

--- a/spec/breadcrumbs_spec.rb
+++ b/spec/breadcrumbs_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe GovukNavigationHelpers::Breadcrumbs do
       breadcrumbs = breadcrumbs_for(content_item)
 
       expect(breadcrumbs).to eq(
-        [
+        breadcrumbs: [
           { title: "Home", url: "/" },
         ]
       )
@@ -24,7 +24,7 @@ RSpec.describe GovukNavigationHelpers::Breadcrumbs do
       breadcrumbs = breadcrumbs_for(content_item)
 
       expect(breadcrumbs).to eq(
-        [
+        breadcrumbs: [
           { title: "Home", url: "/" },
         ]
       )
@@ -42,7 +42,7 @@ RSpec.describe GovukNavigationHelpers::Breadcrumbs do
       breadcrumbs = breadcrumbs_for(content_item)
 
       expect(breadcrumbs).to eq(
-        [
+        breadcrumbs: [
           { title: "Home", url: "/" },
           { title: "A-parent", url: "/a-parent" }
         ]
@@ -71,7 +71,7 @@ RSpec.describe GovukNavigationHelpers::Breadcrumbs do
       breadcrumbs = breadcrumbs_for(content_item)
 
       expect(breadcrumbs).to eq(
-        [
+        breadcrumbs: [
           { title: "Home", url: "/" },
           { title: "Another-parent", url: "/another-parent" },
           { title: "A-parent", url: "/a-parent" }


### PR DESCRIPTION
This commit changes the breadcrumbs helper to return a hash which can be passed to the `govuk_components` breadcrumbs component. This makes the breadcrumbs helper consistent with the related items helper.