### PR TITLE
Group related items by mainstream browse page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Functionality to generate data for the related items component
+
 ## 1.0.0
 
 * Functionality to generate data for the breadcrumb component

--- a/lib/govuk_navigation_helpers.rb
+++ b/lib/govuk_navigation_helpers.rb
@@ -10,7 +10,8 @@ module GovukNavigationHelpers
 
     # Generate a breacrumb trail
     #
-    # @return [Array<Hash>] Each item is a hash containing `:title` and `:url` for one link in the breadcrumb
+    # @return [Hash] Payload for the GOV.UK breadcrumbs component
+    # @see http://govuk-component-guide.herokuapp.com/components/breadcrumbs
     def breadcrumbs
       Breadcrumbs.new(content_item).breadcrumbs
     end
@@ -18,6 +19,7 @@ module GovukNavigationHelpers
     # Generate a related items payload
     #
     # @return [Hash] Payload for the GOV.UK Component
+    # @see http://govuk-component-guide.herokuapp.com/components/related_items
     def related_items
       RelatedItems.new(content_item).related_items
     end

--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -1,6 +1,6 @@
 module GovukNavigationHelpers
   # Simple wrapper around a content store representation of a content item. Works
-  # for both the main content item as the expanded links in the links hash.
+  # for both the main content item and the expanded links in the links hash.
   #
   # @private
   class ContentItem
@@ -14,6 +14,12 @@ module GovukNavigationHelpers
       parent_item = content_store_response.dig("links", "parent", 0)
       return unless parent_item
       ContentItem.new(parent_item)
+    end
+
+    def mainstream_browse_pages
+      content_store_response.dig("links", "mainstream_browse_pages").to_a.map do |link|
+        ContentItem.new(link)
+      end
     end
 
     def title

--- a/lib/govuk_navigation_helpers/grouped_related_links.rb
+++ b/lib/govuk_navigation_helpers/grouped_related_links.rb
@@ -11,34 +11,35 @@ module GovukNavigationHelpers
       @content_item = content_item
     end
 
-    # This will return related items that have the same `parent` (breadcrumb)
-    # as the content item.
-    def related_with_parent_in_common
+    # This will return related items that are tagged to the same mainstream
+    # browse page as the main content item.
+    def tagged_to_same_mainstream_browse_page
       return [] unless content_item.parent
 
-      @related_with_parent_in_common ||= content_item.related_links.select do |related_item|
-        next unless related_item.parent
-        related_item.parent.content_id == content_item.parent.content_id
+      @tagged_to_same_mainstream_browse_page ||= content_item.related_links.select do |related_item|
+        related_item.mainstream_browse_pages.map(&:content_id).include?(content_item.parent.content_id)
       end
     end
 
-    # This will contain related items that have a grandparent in common with
-    # the content item.
-    def related_with_grandparent_in_common
+    # This will return related items whose parents are tagged to the same mainstream
+    # browse page as the main content item's parent.
+    def parents_tagged_to_same_mainstream_browse_page
       return [] unless content_item.parent && content_item.parent.parent
 
-      @related_with_grandparent_in_common ||= content_item.related_links.select do |related_item|
-        next unless related_item.parent && related_item.parent.parent
-        related_item.parent.parent.content_id == content_item.parent.parent.content_id
+      common_parent_content_ids = tagged_to_same_mainstream_browse_page.map(&:content_id)
+
+      @parents_tagged_to_same_mainstream_browse_page ||= content_item.related_links.select do |related_item|
+        next if common_parent_content_ids.include?(related_item.content_id)
+        related_item.mainstream_browse_pages.map(&:parent).map(&:content_id).include?(content_item.parent.parent.content_id)
       end
     end
 
-    # This will contain the related items that have a completely different
-    # parent/breadcrumb from the content item.
-    def related_with_no_parents_in_common
-      all_content_ids = (related_with_parent_in_common + related_with_grandparent_in_common).map(&:content_id)
+    # This will return related links that are tagged to mainstream browse
+    # pages unrelated to the main content item.
+    def tagged_to_different_mainstream_browse_pages
+      all_content_ids = (tagged_to_same_mainstream_browse_page + parents_tagged_to_same_mainstream_browse_page).map(&:content_id)
 
-      @related_with_no_parents_in_common ||= content_item.related_links.reject do |related_item|
+      @tagged_to_different_mainstream_browse_pages ||= content_item.related_links.reject do |related_item|
         all_content_ids.include?(related_item.content_id)
       end
     end

--- a/lib/govuk_navigation_helpers/related_items.rb
+++ b/lib/govuk_navigation_helpers/related_items.rb
@@ -20,9 +20,9 @@ module GovukNavigationHelpers
     def related_items
       {
         sections: [
-          with_parent_in_common_section,
-          with_grandparent_in_common_section,
-          elsewhere_on_govuk_section,
+          tagged_to_same_mainstream_browse_page_section,
+          parents_tagged_to_same_mainstream_browse_page_section,
+          tagged_to_different_mainstream_browse_pages_section,
           related_external_links_section,
         ].compact
       }
@@ -32,10 +32,10 @@ module GovukNavigationHelpers
 
     attr_reader :content_item
 
-    def with_parent_in_common_section
-      return unless grouped.related_with_parent_in_common.any?
+    def tagged_to_same_mainstream_browse_page_section
+      return unless grouped.tagged_to_same_mainstream_browse_page.any?
 
-      items = grouped.related_with_parent_in_common.map do |related_item|
+      items = grouped.tagged_to_same_mainstream_browse_page.map do |related_item|
         {
           title: related_item.title,
           url: related_item.base_path
@@ -45,10 +45,10 @@ module GovukNavigationHelpers
       { title: content_item.parent.title, url: content_item.parent.base_path, items: items }
     end
 
-    def with_grandparent_in_common_section
-      return unless grouped.related_with_grandparent_in_common.any?
+    def parents_tagged_to_same_mainstream_browse_page_section
+      return unless grouped.parents_tagged_to_same_mainstream_browse_page.any?
 
-      items = grouped.related_with_grandparent_in_common.map do |related_item|
+      items = grouped.parents_tagged_to_same_mainstream_browse_page.map do |related_item|
         {
           title: related_item.title,
           url: related_item.base_path
@@ -58,10 +58,10 @@ module GovukNavigationHelpers
       { title: content_item.parent.parent.title, url: content_item.parent.parent.base_path, items: items }
     end
 
-    def elsewhere_on_govuk_section
-      return unless grouped.related_with_no_parents_in_common.any?
+    def tagged_to_different_mainstream_browse_pages_section
+      return unless grouped.tagged_to_different_mainstream_browse_pages.any?
 
-      items = grouped.related_with_no_parents_in_common.map do |related_item|
+      items = grouped.tagged_to_different_mainstream_browse_pages.map do |related_item|
         {
           title: related_item.title,
           url: related_item.base_path

--- a/spec/related_items_spec.rb
+++ b/spec/related_items_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe GovukNavigationHelpers::RelatedItems do
       expect(nothing).to eql(sections: [])
     end
 
-    it "returns an elswhere on GOV.UK section" do
+    it "returns an elswhere on GOV.UK section for related items with no browse pages in common" do
       payload = payload_for(
         "details" => {
           "external_related_links" => []
@@ -55,7 +55,7 @@ RSpec.describe GovukNavigationHelpers::RelatedItems do
       )
     end
 
-    it "includes the external related links" do
+    it "returns the external related links" do
       payload = payload_for(
         "details" => {
           "external_related_links" => [
@@ -80,7 +80,7 @@ RSpec.describe GovukNavigationHelpers::RelatedItems do
       )
     end
 
-    it "creates a primary section for related items with the same breadcrumb as the item" do
+    it "returns a primary section for related items tagged to the same mainstream browse page as the item" do
       payload = payload_for(
         "details" => {
           "external_related_links" => []
@@ -101,7 +101,7 @@ RSpec.describe GovukNavigationHelpers::RelatedItems do
               "base_path" => "/bar",
               "locale" => "en",
               "links" => {
-                "parent" => [
+                "mainstream_browse_pages" => [
                   {
                     "title" => "Foo's parent",
                     "content_id" => "a9c6f24a-92a1-4ead-a776-532d1d99123c",
@@ -128,7 +128,7 @@ RSpec.describe GovukNavigationHelpers::RelatedItems do
       )
     end
 
-    it "creates a secondary section for related items with the same breadcrumb-parent as the item" do
+    it "returns a secondary section for related items tagged to the same mainstream browse page as the item's parent" do
       payload = payload_for(
         "details" => {
           "external_related_links" => []
@@ -159,7 +159,7 @@ RSpec.describe GovukNavigationHelpers::RelatedItems do
               "base_path" => "/bar",
               "locale" => "en",
               "links" => {
-                "parent" => [
+                "mainstream_browse_pages" => [
                   {
                     "title" => "Some sibling of foo-parent",
                     "content_id" => "c34672dc-2ff3-4d28-92fd-bcba382e8a0b",
@@ -188,6 +188,74 @@ RSpec.describe GovukNavigationHelpers::RelatedItems do
           {
             title: "Foo's grandparent",
             url: "/foo-grand-parent",
+            items: [
+              { title: "Foo", url: "/bar" },
+            ]
+          },
+        ]
+      )
+    end
+
+    it "returns only related items in the primary section where they are tagged to the same mainstream browse pages as both the item and the item's parent" do
+      payload = payload_for(
+        "details" => {
+          "external_related_links" => []
+        },
+        "links" => {
+          "parent" => [
+            {
+              "title" => "Foo's parent",
+              "content_id" => "67c28e19-9934-462c-b174-db5b8e566384",
+              "base_path" => "/foo-parent",
+              "locale" => "en",
+              "links" => {
+                "parent" => [
+                  {
+                    "title" => "Foo's grandparent",
+                    "content_id" => "a9c6f24a-92a1-4ead-a776-532d1d99123c",
+                    "base_path" => "/foo-grand-parent",
+                    "locale" => "en",
+                  }
+                ]
+              }
+            }
+          ],
+          "ordered_related_items" => [
+            {
+              "content_id" => "9effaabe-346d-4ad0-9c1b-baa49bc084d6",
+              "title" => "Foo",
+              "base_path" => "/bar",
+              "locale" => "en",
+              "links" => {
+                "mainstream_browse_pages" => [
+                  {
+                    "title" => "Foo's parent",
+                    "content_id" => "67c28e19-9934-462c-b174-db5b8e566384",
+                    "base_path" => "/foo-parent",
+                    "locale" => "en",
+                    "links" => {
+                      "parent" => [
+                        {
+                          "title" => "Foo's grandparent",
+                          "content_id" => "a9c6f24a-92a1-4ead-a776-532d1d99123c",
+                          "base_path" => "/foo-grand-parent",
+                          "locale" => "en",
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      )
+
+      expect(payload).to eql(
+        sections: [
+          {
+            title: "Foo's parent",
+            url: "/foo-parent",
             items: [
               { title: "Foo", url: "/bar" },
             ]


### PR DESCRIPTION
Currently, related items are grouped based on having a common parent or grandparent with the content item they are linked to. This commit changes the grouping logic to group by common `mainstream_browse_pages`, in order to match the currently implemented grouping logic.