### PR TITLE
Add taxon breadcrumb processing

### DIFF
--- a/lib/govuk_navigation_helpers.rb
+++ b/lib/govuk_navigation_helpers.rb
@@ -1,6 +1,7 @@
 require "govuk_navigation_helpers/version"
 require "govuk_navigation_helpers/breadcrumbs"
 require "govuk_navigation_helpers/related_items"
+require "govuk_navigation_helpers/taxon_breadcrumbs"
 
 module GovukNavigationHelpers
   class NavigationHelper
@@ -8,12 +9,20 @@ module GovukNavigationHelpers
       @content_item = content_item
     end
 
-    # Generate a breacrumb trail
+    # Generate a breadcrumb trail
     #
     # @return [Hash] Payload for the GOV.UK breadcrumbs component
     # @see http://govuk-component-guide.herokuapp.com/components/breadcrumbs
     def breadcrumbs
       Breadcrumbs.new(content_item).breadcrumbs
+    end
+
+    # Generate a breadcrumb trail for a taxon, using the taxon_parent link field
+    #
+    # @return [Hash] Payload for the GOV.UK breadcrumbs component
+    # @see http://govuk-component-guide.herokuapp.com/components/breadcrumbs
+    def taxon_breadcrumbs
+      TaxonBreadcrumbs.new(content_item).breadcrumbs
     end
 
     # Generate a related items payload

--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -16,6 +16,13 @@ module GovukNavigationHelpers
       ContentItem.new(parent_item)
     end
 
+    def parent_taxon
+      # TODO: Determine what to do when there are multiple parents. For now just display the first
+      parent_taxon = content_store_response.dig("links", "parent_taxons", 0)
+      return unless parent_taxon
+      ContentItem.new(parent_taxon)
+    end
+
     def mainstream_browse_pages
       content_store_response.dig("links", "mainstream_browse_pages").to_a.map do |link|
         ContentItem.new(link)

--- a/lib/govuk_navigation_helpers/taxon_breadcrumbs.rb
+++ b/lib/govuk_navigation_helpers/taxon_breadcrumbs.rb
@@ -1,0 +1,35 @@
+module GovukNavigationHelpers
+  class TaxonBreadcrumbs
+    def initialize(content_item)
+      @content_item = ContentItem.new(content_item)
+    end
+
+    def breadcrumbs
+      ordered_parents = all_parents.map do |parent|
+        { title: parent.title, url: parent.base_path }
+      end
+
+      ordered_parents << { title: "Home", url: "/" }
+
+      {
+          breadcrumbs: ordered_parents.reverse
+      }
+    end
+
+  private
+
+    attr_reader :content_item
+
+    def all_parents
+      parents = []
+
+      direct_parent = content_item.parent_taxon
+      while direct_parent
+        parents << direct_parent
+        direct_parent = direct_parent.parent_taxon
+      end
+
+      parents
+    end
+  end
+end

--- a/spec/taxon_breadcrumbs_spec.rb
+++ b/spec/taxon_breadcrumbs_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+
+RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
+  describe "Taxon breadcrumbs" do
+    it "can handle any valid content item" do
+      generator = GovukSchemas::RandomExample.for_schema("taxon", schema_type: "frontend")
+
+      expect { GovukNavigationHelpers::TaxonBreadcrumbs.new(generator.payload).breadcrumbs }.to_not raise_error
+    end
+
+    it "returns the root when parent is not specified" do
+      content_item = { "links" => {} }
+      breadcrumbs = breadcrumbs_for(content_item)
+
+      expect(breadcrumbs).to eq(
+        breadcrumbs: [
+          { title: "Home", url: "/" },
+        ]
+      )
+    end
+
+    it "returns the root when parent is empty" do
+      content_item = content_item_with_parents([])
+      breadcrumbs = breadcrumbs_for(content_item)
+
+      expect(breadcrumbs).to eq(
+        breadcrumbs: [
+          { title: "Home", url: "/" },
+        ]
+      )
+    end
+
+    it "places parent under the root when there is a parent" do
+      parent = {
+          "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+          "locale" => "en",
+          "title" => "A-parent",
+          "base_path" => "/a-parent",
+      }
+
+      content_item = content_item_with_parents([parent])
+      breadcrumbs = breadcrumbs_for(content_item)
+
+      expect(breadcrumbs).to eq(
+        breadcrumbs: [
+          { title: "Home", url: "/" },
+          { title: "A-parent", url: "/a-parent" }
+        ]
+      )
+    end
+
+    it "includes grandparent when available" do
+      grandparent = {
+          "title" => "Another-parent",
+          "base_path" => "/another-parent",
+          "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+          "locale" => "en",
+      }
+
+      parent = {
+          "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+          "locale" => "en",
+          "title" => "A-parent",
+          "base_path" => "/a-parent",
+          "links" => {
+              "parent_taxons" => [grandparent]
+          }
+      }
+
+      content_item = content_item_with_parents([parent])
+      breadcrumbs = breadcrumbs_for(content_item)
+
+      expect(breadcrumbs).to eq(
+        breadcrumbs: [
+          { title: "Home", url: "/" },
+          { title: "Another-parent", url: "/another-parent" },
+          { title: "A-parent", url: "/a-parent" }
+        ]
+      )
+    end
+  end
+
+  def breadcrumbs_for(content_item)
+    generator = GovukSchemas::RandomExample.for_schema("taxon", schema_type: "frontend")
+    fully_valid_content_item = generator.merge_and_validate(content_item)
+
+    # Use the main class instead of GovukNavigationHelpers::Breadcrumbs, so that
+    # we're testing both at the same time.
+    GovukNavigationHelpers::NavigationHelper.new(fully_valid_content_item).taxon_breadcrumbs
+  end
+
+  def content_item_with_parents(parents)
+    {
+        "links" => { "parent_taxons" => parents }
+    }
+  end
+end


### PR DESCRIPTION
This change adds a navigation helper to get the payload required to render breadcrumbs for taxons. This is called with:
`NavigationHelper.new(content_item).taxon_breadcrumbs`

The code is a direct read-across of the (non-taxon) breadcrumb helper.

Trello: https://trello.com/c/6OIbW5Ad/323-add-functionality-to-govuk-navigation-helpers-to-generate-data-for-the-breadcrumbs-from-the-new-taxonomy