### PR TITLE
Migrate to Jenkins 2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,48 @@
+#!/usr/bin/env groovy
+
+node {
+  def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+
+  try {
+    stage('Checkout') {
+      checkout scm
+    }
+
+    stage('Clean') {
+      govuk.cleanupGit()
+      govuk.mergeMasterBranch()
+    }
+
+    stage("Set up content schema dependency") {
+      govuk.contentSchemaDependency()
+    }
+
+    stage('Bundle') {
+      echo 'Bundling'
+      sh("bundle install --path ${JENKINS_HOME}/bundles/${JOB_NAME}")
+    }
+
+    stage('Linter') {
+      govuk.rubyLinter()
+    }
+
+    stage('Tests') {
+      govuk.setEnvar('RAILS_ENV', 'test')
+      govuk.runTests('spec')
+    }
+
+    if(env.BRANCH_NAME == "master") {
+      stage('Publish Gem') {
+        govuk.runRakeTask("publish_gem --trace")
+      }
+    }
+
+  } catch (e) {
+    currentBuild.result = 'FAILED'
+    step([$class: 'Mailer',
+          notifyEveryUnstableBuild: true,
+          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
+          sendToIndividuals: true])
+    throw e
+  }
+}


### PR DESCRIPTION
This moves the Gem onto [Jenkins 2](https://ci.integration.publishing.service.gov.uk/job/govuk_navigation_helpers/).

The Gem publication stage needs to be tested; this will be done in a subsequent Pull Request.