### PR TITLE
Add ssh tagging permission to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,9 @@ node {
 
     if(env.BRANCH_NAME == "master") {
       stage('Publish Gem') {
-        govuk.runRakeTask("publish_gem --trace")
+        sshagent(['govuk-ci-ssh-key']) {
+          govuk.runRakeTask("publish_gem --trace")
+        }
       }
     }
 


### PR DESCRIPTION
This should add the correct ssh permissions required by the gem publisher to push a tag to Git.