### PR TITLE
[DISCUSS] Refactor breadcrumbs to work with publishing api

### DIFF
--- a/lib/govuk_navigation_helpers.rb
+++ b/lib/govuk_navigation_helpers.rb
@@ -14,7 +14,9 @@ module GovukNavigationHelpers
     # @return [Hash] Payload for the GOV.UK breadcrumbs component
     # @see http://govuk-component-guide.herokuapp.com/components/breadcrumbs
     def breadcrumbs
-      Breadcrumbs.new(content_item).breadcrumbs
+      NavigationHelper.format_breadcrumb_for_component(
+        Breadcrumbs.from_content_store_response(content_item).breadcrumbs
+      )
     end
 
     # Generate a breadcrumb trail for a taxon, using the taxon_parent link field
@@ -22,7 +24,9 @@ module GovukNavigationHelpers
     # @return [Hash] Payload for the GOV.UK breadcrumbs component
     # @see http://govuk-component-guide.herokuapp.com/components/breadcrumbs
     def taxon_breadcrumbs
-      TaxonBreadcrumbs.new(content_item).breadcrumbs
+      NavigationHelper.format_breadcrumb_for_component(
+        TaxonBreadcrumbs.from_content_store_response(content_item).breadcrumbs
+      )
     end
 
     # Generate a related items payload
@@ -31,6 +35,18 @@ module GovukNavigationHelpers
     # @see http://govuk-component-guide.herokuapp.com/components/related_items
     def related_items
       RelatedItems.new(content_item).related_items
+    end
+
+    def self.format_breadcrumb_for_component(all_parents)
+      breadcrumbs = all_parents.map do |parent|
+        { title: parent.title, url: parent.base_path }
+      end
+
+      breadcrumbs.unshift(title: "Home", url: "/")
+
+      {
+        breadcrumbs: breadcrumbs
+      }
     end
 
   private

--- a/lib/govuk_navigation_helpers/breadcrumbs.rb
+++ b/lib/govuk_navigation_helpers/breadcrumbs.rb
@@ -1,19 +1,22 @@
+require 'govuk_navigation_helpers/content_item'
+require 'govuk_navigation_helpers/publishing_api_linked_edition'
+
 module GovukNavigationHelpers
   class Breadcrumbs
     def initialize(content_item)
-      @content_item = ContentItem.new(content_item)
+      @content_item = content_item
+    end
+
+    def self.from_expanded_links_response(**options)
+      new(PublishingApiLinkedEdition(options))
+    end
+
+    def self.from_content_store_response(content_store_response)
+      new(ContentItem.new(content_store_response))
     end
 
     def breadcrumbs
-      ordered_parents = all_parents.map do |parent|
-        { title: parent.title, url: parent.base_path }
-      end
-
-      ordered_parents << { title: "Home", url: "/" }
-
-      {
-        breadcrumbs: ordered_parents.reverse
-      }
+      all_parents.reverse
     end
 
   private

--- a/lib/govuk_navigation_helpers/publishing_api_linked_edition.rb
+++ b/lib/govuk_navigation_helpers/publishing_api_linked_edition.rb
@@ -1,0 +1,62 @@
+module GovukNavigationHelpers
+  # Wrapper around a publishing api representation of the expanded links.
+  #
+  # @private
+  class PublishingApiLinkedEdition
+    attr_reader :title, :base_path, :content_id
+
+    def initialize(title:, base_path:, content_id:, links: {})
+      @links = links
+      @title = title
+      @base_path = base_path
+      @content_id = content_id
+    end
+
+    def self.from_nested_item(nested_item)
+      new(
+        title: nested_item["title"],
+        base_path: nested_item["base_path"],
+        content_id: nested_item["content_id"],
+        links: nested_item["links"]
+      )
+    end
+
+    def self.from_expanded_links_response(base_path:, title:, expanded_links_response:)
+      new(
+        title: title,
+        base_path: base_path,
+        content_id: expanded_links_response["content_id"],
+        links: expanded_links_response["expanded_links"]
+      )
+    end
+
+    def parent
+      parent_item = expanded_links.dig("links", "parent", 0)
+      return unless parent_item
+      PublishingApiLinkedEdition.from_nested_item(parent_item)
+    end
+
+    def parent_taxon
+      # TODO: Determine what to do when there are multiple parents. For now just display the first
+      parent_taxon = links.dig("parent_taxons", 0)
+      return unless parent_taxon
+      PublishingApiLinkedEdition.from_nested_item(parent_taxon)
+    end
+
+    def mainstream_browse_pages
+      links.dig("mainstream_browse_pages").to_a.map do |link|
+        PublishingApiLinkedEdition.from_nested_item(link)
+      end
+    end
+
+    def related_links
+      links.dig("ordered_related_items").to_a.map do |link|
+        PublishingApiLinkedEdition.from_nested_item(link)
+      end
+    end
+
+  private
+
+    attr_reader :links
+  end
+end

--- a/lib/govuk_navigation_helpers/taxon_breadcrumbs.rb
+++ b/lib/govuk_navigation_helpers/taxon_breadcrumbs.rb
@@ -1,19 +1,28 @@
+require 'govuk_navigation_helpers/content_item'
+require 'govuk_navigation_helpers/publishing_api_linked_edition'
+
 module GovukNavigationHelpers
   class TaxonBreadcrumbs
     def initialize(content_item)
-      @content_item = ContentItem.new(content_item)
+      @content_item = content_item
+    end
+
+    def self.from_expanded_links_response(expanded_links_response:, title:, base_path:)
+      new(
+        PublishingApiLinkedEdition.from_expanded_links_response(
+          expanded_links_response: expanded_links_response,
+          title: title,
+          base_path: base_path
+        )
+      )
+    end
+
+    def self.from_content_store_response(content_store_response)
+      new(ContentItem.new(content_store_response))
     end
 
     def breadcrumbs
-      ordered_parents = all_parents.map do |parent|
-        { title: parent.title, url: parent.base_path }
-      end
-
-      ordered_parents << { title: "Home", url: "/" }
-
-      {
-          breadcrumbs: ordered_parents.reverse
-      }
+      all_parents.reverse
     end
 
   private

--- a/spec/breadcrumbs_spec.rb
+++ b/spec/breadcrumbs_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe GovukNavigationHelpers::Breadcrumbs do
     it "can handle any valid content item" do
       generator = GovukSchemas::RandomExample.for_schema("placeholder", schema_type: "frontend")
 
-      expect { GovukNavigationHelpers::Breadcrumbs.new(generator.payload).breadcrumbs }.to_not raise_error
+      expect { GovukNavigationHelpers::Breadcrumbs.from_content_store_response(generator.payload).breadcrumbs }.to_not raise_error
     end
 
     it "returns the root when parent is not specified" do

--- a/spec/taxon_breadcrumbs_spec.rb
+++ b/spec/taxon_breadcrumbs_spec.rb
@@ -5,7 +5,51 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
     it "can handle any valid content item" do
       generator = GovukSchemas::RandomExample.for_schema("taxon", schema_type: "frontend")
 
-      expect { GovukNavigationHelpers::TaxonBreadcrumbs.new(generator.payload).breadcrumbs }.to_not raise_error
+      expect { GovukNavigationHelpers::TaxonBreadcrumbs.from_content_store_response(generator.payload).breadcrumbs }.to_not raise_error
+    end
+
+    context "using the publishing api expanded links response" do
+      it "includes grandparent when available" do
+        grandparent = {
+            "title" => "Another-parent",
+            "base_path" => "/another-parent",
+            "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+            "locale" => "en",
+            "links" => {}
+        }
+
+        parent = {
+            "content_id" => "20c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+            "locale" => "en",
+            "title" => "A-parent",
+            "base_path" => "/a-parent",
+            "links" => {
+                "parent_taxons" => [grandparent]
+            }
+        }
+
+        links = {
+          "parent_taxons" => [parent]
+        }
+
+        expanded_links_response = {
+          "content_id" => "10c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+          "version" => 1,
+          "expanded_links" => links
+        }
+
+        breadcrumbs = GovukNavigationHelpers::TaxonBreadcrumbs.from_expanded_links_response(
+          expanded_links_response: expanded_links_response,
+          title: "My content",
+          base_path: "/my-content"
+        ).breadcrumbs
+
+        breadcrumb_titles = breadcrumbs.map(&:title)
+
+        expect(breadcrumb_titles).to eq(
+          %w(Another-parent A-parent)
+        )
+      end
     end
 
     it "returns the root when taxon is not specified" do


### PR DESCRIPTION
The code for flattening nested links hashes into breadcrumbs is useful in other GOV.UK apps besides navigation, for example:

- in rummager we want to tag a document with all its breadcrumb topics at indexing time
- in whitehall we want to show a preview of the breadcrumb for every topic we tag to

The existing Breadcrumb and TaxonBreadcrumb classes worked on ContentItem objects. This class represents a content item, but it's coupled to the content store representation because it parses the response on the fly.

In publishing apps, we call a publishing api method, `GET expanded-links`, which has a slightly different response, but with the same basic structure for links.

We've added a new class - `PublishingApiLinkedEdition` - to parse expanded-links responses, and made `TaxonBreadcrumb` and `Breadcrumb` work with both of them.

There is overlap between the implementations of `PublishingApiLinkedEdition` and `ContentItem`, but there are also subtle differences between the two responses, so I think it makes sense to keep them separate.

This changes the API for using `TaxonBreadcrumb` and `Breadcrumb` directly, but keeps `NavigationHelper` (which is what the frontend actually uses at the moment) the same. 

If this refactor is OK, I'm planning to add a method to `TaxonBreadcrumb` to generate breadcrumbs of all `taxons` links tagged to a content item. The implementation of this currently exists in [whitehall](https://github.com/alphagov/whitehall/blob/af45d757327127f2e446f3b39a52c436cc36fa2b/app/services/expanded_links_fetcher.rb).

Paired with @klssmith 
Trello: https://trello.com/c/dIMlC5JH/481-index-parents-of-the-taxon-for-each-page