### PR TITLE
Fix taxon breadcrumbs

### DIFF
--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -17,10 +17,12 @@ module GovukNavigationHelpers
     end
 
     def parent_taxon
-      # TODO: Determine what to do when there are multiple parents. For now just display the first
+      # TODO: Determine what to do when there are multiple taxons/parents. For now just display the first of each.
+      taxon = content_store_response.dig("links", "taxons", 0)
+      return ContentItem.new(taxon) if taxon
+
       parent_taxon = content_store_response.dig("links", "parent_taxons", 0)
-      return unless parent_taxon
-      ContentItem.new(parent_taxon)
+      return ContentItem.new(parent_taxon) if parent_taxon
     end
 
     def mainstream_browse_pages

--- a/spec/taxon_breadcrumbs_spec.rb
+++ b/spec/taxon_breadcrumbs_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
       expect { GovukNavigationHelpers::TaxonBreadcrumbs.new(generator.payload).breadcrumbs }.to_not raise_error
     end
 
-    it "returns the root when parent is not specified" do
+    it "returns the root when taxon is not specified" do
       content_item = { "links" => {} }
       breadcrumbs = breadcrumbs_for(content_item)
 
@@ -19,37 +19,19 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
       )
     end
 
-    it "returns the root when parent is empty" do
+    it "places parent under the root when there is a taxon" do
       content_item = content_item_with_parents([])
       breadcrumbs = breadcrumbs_for(content_item)
 
       expect(breadcrumbs).to eq(
         breadcrumbs: [
           { title: "Home", url: "/" },
+          { title: "Taxon", url: "/a-taxon" }
         ]
       )
     end
 
-    it "places parent under the root when there is a parent" do
-      parent = {
-          "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
-          "locale" => "en",
-          "title" => "A-parent",
-          "base_path" => "/a-parent",
-      }
-
-      content_item = content_item_with_parents([parent])
-      breadcrumbs = breadcrumbs_for(content_item)
-
-      expect(breadcrumbs).to eq(
-        breadcrumbs: [
-          { title: "Home", url: "/" },
-          { title: "A-parent", url: "/a-parent" }
-        ]
-      )
-    end
-
-    it "includes grandparent when available" do
+    it "includes parents and grandparents when available" do
       grandparent = {
           "title" => "Another-parent",
           "base_path" => "/another-parent",
@@ -74,7 +56,8 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
         breadcrumbs: [
           { title: "Home", url: "/" },
           { title: "Another-parent", url: "/another-parent" },
-          { title: "A-parent", url: "/a-parent" }
+          { title: "A-parent", url: "/a-parent" },
+          { title: "Taxon", url: "/a-taxon" },
         ]
       )
     end
@@ -91,7 +74,19 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
 
   def content_item_with_parents(parents)
     {
-        "links" => { "parent_taxons" => parents }
+      "links" => {
+        "taxons" => [
+          {
+            "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+            "locale" => "en",
+            "title" => "Taxon",
+            "base_path" => "/a-taxon",
+            "links" => {
+              "parent_taxons" => parents
+            },
+          },
+        ],
+      },
     }
   end
 end


### PR DESCRIPTION
Prior to this change, the format used in the `taxon_breadcrumbs` method was incorrect. That assumed a content item to have the following structure:

```json
{
  "links": {
    "parent_taxons": []
  }
}
```

This skipped out the taxon that the content was actually tagged to, so the format should actually be:

```json
{
  "links": {
    "taxons": [
      {
        "links": {
          "parent_taxons": []
        }
      }
    ]
  }
}
```