### PR TITLE
Add rubocop yaml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+AllCops:
+  TargetRubyVersion: 2.3


### PR DESCRIPTION
For some reason rubocop isn't picking up the ruby version properly on one of
our branches (https://github.com/alphagov/govuk_navigation_helpers/pull/26)

Force it to use the 2.3 parser.