### PR TITLE
Show current page in breadcrumbs

### DIFF
--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -52,5 +52,9 @@ module GovukNavigationHelpers
     def external_links
       content_store_response.dig("details", "external_related_links").to_a
     end
+
+    def is_a_taxon?
+      content_store_response.fetch("document_type") == "taxon"
+    end
   end
 end

--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -52,9 +52,5 @@ module GovukNavigationHelpers
     def external_links
       content_store_response.dig("details", "external_related_links").to_a
     end
-
-    def is_a_taxon?
-      content_store_response.fetch("document_type") == "taxon"
-    end
   end
 end

--- a/lib/govuk_navigation_helpers/taxon_breadcrumbs.rb
+++ b/lib/govuk_navigation_helpers/taxon_breadcrumbs.rb
@@ -11,8 +11,11 @@ module GovukNavigationHelpers
 
       ordered_parents << { title: "Home", url: "/" }
 
+      ordered_breadcrumbs = ordered_parents.reverse
+      ordered_breadcrumbs << { title: content_item.title, url: "#content" }
+
       {
-          breadcrumbs: ordered_parents.reverse
+        breadcrumbs: ordered_breadcrumbs
       }
     end
 

--- a/lib/govuk_navigation_helpers/taxon_breadcrumbs.rb
+++ b/lib/govuk_navigation_helpers/taxon_breadcrumbs.rb
@@ -12,7 +12,7 @@ module GovukNavigationHelpers
       ordered_parents << { title: "Home", url: "/" }
 
       ordered_breadcrumbs = ordered_parents.reverse
-      ordered_breadcrumbs << { title: content_item.title, url: "#content" }
+      ordered_breadcrumbs << { title: content_item.title, is_current_page: true }
 
       {
         breadcrumbs: ordered_breadcrumbs

--- a/spec/taxon_breadcrumbs_spec.rb
+++ b/spec/taxon_breadcrumbs_spec.rb
@@ -16,12 +16,13 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
     end
 
     it "returns the root when taxon is not specified" do
-      content_item = { "links" => {} }
+      content_item = { "title" => "Some Content", "links" => {} }
       breadcrumbs = breadcrumbs_for(content_item)
 
       expect(breadcrumbs).to eq(
         breadcrumbs: [
           { title: "Home", url: "/" },
+          { title: "Some Content", url: "#content" }
         ]
       )
     end
@@ -33,7 +34,8 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
       expect(breadcrumbs).to eq(
         breadcrumbs: [
           { title: "Home", url: "/" },
-          { title: "Taxon", url: "/taxon" }
+          { title: "Taxon", url: "/taxon" },
+          { title: "Some Content", url: "#content" },
         ]
       )
     end
@@ -66,12 +68,13 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
             { title: "Another-parent", url: "/another-parent" },
             { title: "A-parent", url: "/a-parent" },
             { title: "Taxon", url: "/taxon" },
+            { title: "Some Content", url: "#content" },
           ]
         )
       end
     end
 
-    context 'with a content item tagged to taxons' do
+    context 'with a taxon with parent taxons' do
       it "includes parents and grandparents when available" do
         parent = {
             "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
@@ -90,7 +93,7 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
           breadcrumbs: [
             { title: "Home", url: "/" },
             { title: "A-parent", url: "/a-parent" },
-            { title: "Taxon", url: "/taxon" },
+            { title: "Taxon", url: "#content" },
           ]
         )
       end
@@ -108,26 +111,18 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
 
   def taxon_with_parent_taxons(parents)
     {
-      "title" => "A taxon",
+      "title" => "Taxon",
+      "document_type" => "taxon",
       "links" => {
-        "parent_taxons" => [
-          {
-            "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
-            "locale" => "en",
-            "title" => "Taxon",
-            "base_path" => "/taxon",
-            "links" => {
-              "parent_taxons" => parents
-            },
-          },
-        ],
+        "parent_taxons" => parents,
       },
     }
   end
 
   def content_item_tagged_to_taxon(parents)
     {
-      "title" => "A piece of content",
+      "title" => "Some Content",
+      "document_type" => "guidance",
       "links" => {
         "taxons" => [
           {

--- a/spec/taxon_breadcrumbs_spec.rb
+++ b/spec/taxon_breadcrumbs_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
       expect(breadcrumbs).to eq(
         breadcrumbs: [
           { title: "Home", url: "/" },
-          { title: "Some Content", url: "#content" }
+          { title: "Some Content", is_current_page: true }
         ]
       )
     end
@@ -35,7 +35,7 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
         breadcrumbs: [
           { title: "Home", url: "/" },
           { title: "Taxon", url: "/taxon" },
-          { title: "Some Content", url: "#content" },
+          { title: "Some Content", is_current_page: true },
         ]
       )
     end
@@ -68,7 +68,7 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
             { title: "Another-parent", url: "/another-parent" },
             { title: "A-parent", url: "/a-parent" },
             { title: "Taxon", url: "/taxon" },
-            { title: "Some Content", url: "#content" },
+            { title: "Some Content", is_current_page: true },
           ]
         )
       end
@@ -93,7 +93,7 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
           breadcrumbs: [
             { title: "Home", url: "/" },
             { title: "A-parent", url: "/a-parent" },
-            { title: "Taxon", url: "#content" },
+            { title: "Taxon", is_current_page: true },
           ]
         )
       end


### PR DESCRIPTION
For any pages displaying "taxon" breadcrumbs, we will now display the title of the current page as the final breadcrumb. Clicking on this link will take users to the `#content` anchor on the page.

Dependent on:
- [x] https://github.com/alphagov/static/pull/901

Trello: https://trello.com/c/MVM5bueS/386-add-current-page-to-taxonomy-breadcrumbs