### PR TITLE
Convert content item to hash

### DIFF
--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -7,7 +7,7 @@ module GovukNavigationHelpers
     attr_reader :content_store_response
 
     def initialize(content_store_response)
-      @content_store_response = content_store_response
+      @content_store_response = content_store_response.to_h
     end
 
     def parent


### PR DESCRIPTION
The ContentItem class assumes a number of hash methods that may not
necessarily be available on a content item. By explicitly converting
this object to a hash, we can avoid bad method calls