### PR TITLE
Add a taxon sidebar method

### DIFF
--- a/lib/govuk_navigation_helpers.rb
+++ b/lib/govuk_navigation_helpers.rb
@@ -2,6 +2,7 @@ require "govuk_navigation_helpers/version"
 require "govuk_navigation_helpers/breadcrumbs"
 require "govuk_navigation_helpers/related_items"
 require "govuk_navigation_helpers/taxon_breadcrumbs"
+require "govuk_navigation_helpers/taxon_sidebar"
 
 module GovukNavigationHelpers
   class NavigationHelper
@@ -23,6 +24,15 @@ module GovukNavigationHelpers
     # @see http://govuk-component-guide.herokuapp.com/components/breadcrumbs
     def taxon_breadcrumbs
       TaxonBreadcrumbs.new(content_item).breadcrumbs
+    end
+
+    # Generate a payload containing taxon sidebar data. Intended for use with
+    # the related items component.
+    #
+    # @return [Hash] Payload for the GOV.UK related items component
+    # @see http://govuk-component-guide.herokuapp.com/components/related_items
+    def taxon_sidebar
+      TaxonSidebar.new(content_item).sidebar
     end
 
     # Generate a related items payload

--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -18,12 +18,20 @@ module GovukNavigationHelpers
     end
 
     def parent_taxon
-      # TODO: Determine what to do when there are multiple taxons/parents. For now just display the first of each.
-      taxon = content_store_response.dig("links", "taxons", 0)
-      return ContentItem.new(taxon) if taxon
+      # TODO: Determine what to do when there are multiple taxons/parents. For
+      # now just display the first of each.
+      parent_taxons.first
+    end
 
-      parent_taxon = content_store_response.dig("links", "parent_taxons", 0)
-      return ContentItem.new(parent_taxon) if parent_taxon
+    def parent_taxons
+      # First handle the case for content items tagged to the taxonomy.
+      taxons = Array(content_store_response.dig("links", "taxons"))
+      return taxons.map { |taxon| ContentItem.new(taxon) } if taxons.any?
+
+      # If that link isn't present, assume we're dealing with a taxon and check
+      # for its parents in the taxonomy.
+      parent_taxons = Array(content_store_response.dig("links", "parent_taxons"))
+      parent_taxons.map { |taxon| ContentItem.new(taxon) }
     end
 
     def mainstream_browse_pages

--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -1,6 +1,7 @@
 module GovukNavigationHelpers
-  # Simple wrapper around a content store representation of a content item. Works
-  # for both the main content item and the expanded links in the links hash.
+  # Simple wrapper around a content store representation of a content item.
+  # Works for both the main content item and the expanded links in the links
+  # hash.
   #
   # @private
   class ContentItem

--- a/lib/govuk_navigation_helpers/taxon_sidebar.rb
+++ b/lib/govuk_navigation_helpers/taxon_sidebar.rb
@@ -1,0 +1,22 @@
+module GovukNavigationHelpers
+  class TaxonSidebar
+    def initialize(content_item)
+      @content_item = ContentItem.new content_item
+    end
+
+    def sidebar
+      {
+        sections: taxons.any? ? [{ title: "More about", items: taxons }] : []
+      }
+    end
+
+  private
+
+    def taxons
+      parent_taxons = @content_item.parent_taxons
+      parent_taxons.map do |parent_taxon|
+        { title: parent_taxon.title, url: parent_taxon.base_path }
+      end
+    end
+  end
+end

--- a/spec/taxon_sidebar_spec.rb
+++ b/spec/taxon_sidebar_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+RSpec.describe GovukNavigationHelpers::TaxonSidebar do
+  describe '#sidebar' do
+    it 'can handle any valid content item' do
+      generator = GovukSchemas::RandomExample.for_schema(
+        'placeholder',
+        schema_type: 'frontend'
+      )
+
+      expect { sidebar_for(generator.payload) }.to_not raise_error
+    end
+
+    context 'given a content item not tagged to any taxon' do
+      it 'returns an empty sidebar hash' do
+        content_item = { "links" => {} }
+
+        expect(sidebar_for(content_item)).to eq(
+          sections: []
+        )
+      end
+    end
+
+    context 'given a content item tagged to taxons' do
+      it 'returns a sidebar hash containing a list of parent taxons' do
+        content_item = content_item_tagged_to_taxon
+
+        expect(sidebar_for(content_item)).to eq(
+          sections: [
+            {
+              title: "More about",
+              items: [
+                { title: "Taxon 1", url: "/taxon-1" },
+                { title: "Taxon 2", url: "/taxon-2" },
+              ],
+            }
+          ]
+        )
+      end
+    end
+  end
+
+  def sidebar_for(content_item)
+    GovukNavigationHelpers::NavigationHelper.new(content_item).taxon_sidebar
+  end
+
+  def content_item_tagged_to_taxon
+    {
+      "title" => "A piece of content",
+      "links" => {
+        "taxons" => [
+          {
+            "title" => "Taxon 1",
+            "base_path" => "/taxon-1",
+          },
+          {
+            "title" => "Taxon 2",
+            "base_path" => "/taxon-2",
+          },
+        ],
+      },
+    }
+  end
+end


### PR DESCRIPTION
The new taxonomy navigation requires its content pages to display a
sidebar. The sidebar should contain links to the parent taxons the
content is tagged to.

This commit adds a helper method that accepts a content item payload.
The method uses this payload to generate the appropriate data structure
for the GOVUK sidebar component in static.


https://trello.com/c/0BD3POzu/403-show-parent-taxons-in-the-side-navigation-on-all-education-content-pages