### PR TITLE
Update taxonomy sidebar helper

### DIFF
--- a/lib/govuk_navigation_helpers.rb
+++ b/lib/govuk_navigation_helpers.rb
@@ -2,7 +2,7 @@ require "govuk_navigation_helpers/version"
 require "govuk_navigation_helpers/breadcrumbs"
 require "govuk_navigation_helpers/related_items"
 require "govuk_navigation_helpers/taxon_breadcrumbs"
-require "govuk_navigation_helpers/taxon_sidebar"
+require "govuk_navigation_helpers/taxonomy_sidebar"
 
 module GovukNavigationHelpers
   class NavigationHelper
@@ -31,8 +31,8 @@ module GovukNavigationHelpers
     #
     # @return [Hash] Payload for the GOV.UK related items component
     # @see http://govuk-component-guide.herokuapp.com/components/related_items
-    def taxon_sidebar
-      TaxonSidebar.new(content_item).sidebar
+    def taxonomy_sidebar
+      TaxonomySidebar.new(content_item).sidebar
     end
 
     # Generate a related items payload

--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -48,6 +48,10 @@ module GovukNavigationHelpers
       content_store_response.fetch("base_path")
     end
 
+    def description
+      content_store_response.fetch("description")
+    end
+
     def content_id
       content_store_response.fetch("content_id")
     end

--- a/lib/govuk_navigation_helpers/taxonomy_sidebar.rb
+++ b/lib/govuk_navigation_helpers/taxonomy_sidebar.rb
@@ -1,5 +1,5 @@
 module GovukNavigationHelpers
-  class TaxonSidebar
+  class TaxonomySidebar
     def initialize(content_item)
       @content_item = ContentItem.new content_item
     end
@@ -15,7 +15,11 @@ module GovukNavigationHelpers
     def taxons
       parent_taxons = @content_item.parent_taxons
       parent_taxons.map do |parent_taxon|
-        { title: parent_taxon.title, url: parent_taxon.base_path }
+        {
+          title: parent_taxon.title,
+          url: parent_taxon.base_path,
+          description: parent_taxon.description,
+        }
       end
     end
   end

--- a/spec/taxonomy_sidebar_spec.rb
+++ b/spec/taxonomy_sidebar_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-RSpec.describe GovukNavigationHelpers::TaxonSidebar do
+RSpec.describe GovukNavigationHelpers::TaxonomySidebar do
   describe '#sidebar' do
     it 'can handle any valid content item' do
       generator = GovukSchemas::RandomExample.for_schema(
-        'placeholder',
+        'taxon',
         schema_type: 'frontend'
       )
 
@@ -30,8 +30,8 @@ RSpec.describe GovukNavigationHelpers::TaxonSidebar do
             {
               title: "More about",
               items: [
-                { title: "Taxon 1", url: "/taxon-1" },
-                { title: "Taxon 2", url: "/taxon-2" },
+                { title: "Taxon 1", url: "/taxon-1", description: "The 1st taxon." },
+                { title: "Taxon 2", url: "/taxon-2", description: "The 2nd taxon." },
               ],
             }
           ]
@@ -41,7 +41,7 @@ RSpec.describe GovukNavigationHelpers::TaxonSidebar do
   end
 
   def sidebar_for(content_item)
-    GovukNavigationHelpers::NavigationHelper.new(content_item).taxon_sidebar
+    GovukNavigationHelpers::NavigationHelper.new(content_item).taxonomy_sidebar
   end
 
   def content_item_tagged_to_taxon
@@ -52,10 +52,12 @@ RSpec.describe GovukNavigationHelpers::TaxonSidebar do
           {
             "title" => "Taxon 1",
             "base_path" => "/taxon-1",
+            "description" => "The 1st taxon.",
           },
           {
             "title" => "Taxon 2",
             "base_path" => "/taxon-2",
+            "description" => "The 2nd taxon.",
           },
         ],
       },


### PR DESCRIPTION
- Give it a slightly more generic name, given it doesn't just contain
  taxons. It may also eventually contain links to content items similar
  to the current page, as determined by Rummager.
- Add the taxon description field for use in the sidebar.

For use with the component added here: https://github.com/alphagov/static/pull/905