### PR TITLE
Fix taxonomy_sidebar_spec

### DIFF
--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -49,7 +49,7 @@ module GovukNavigationHelpers
     end
 
     def description
-      content_store_response.fetch("description")
+      content_store_response.fetch("description", "")
     end
 
     def content_id

--- a/spec/taxonomy_sidebar_spec.rb
+++ b/spec/taxonomy_sidebar_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe GovukNavigationHelpers::TaxonomySidebar do
   describe '#sidebar' do
     it 'can handle any valid content item' do
       generator = GovukSchemas::RandomExample.for_schema(
-        'taxon',
+        'placeholder',
         schema_type: 'frontend'
       )
 


### PR DESCRIPTION
* Back out change to random schema example. Using 'taxon' is
  confusing and erroneous as the sidebar is for content pages not taxon
  pages.
* Make description field optional as not all parent taxons will have
  one.