### PR TITLE
Return related content with symbol keys

### DIFF
--- a/lib/govuk_navigation_helpers/taxonomy_sidebar.rb
+++ b/lib/govuk_navigation_helpers/taxonomy_sidebar.rb
@@ -33,7 +33,7 @@ module GovukNavigationHelpers
     # the content store
     def content_related_to(taxon)
       begin
-        Services.rummager.search(
+        results = Services.rummager.search(
           similar_to: @content_item.base_path,
           start: 0,
           count: 5,
@@ -41,6 +41,13 @@ module GovukNavigationHelpers
           filter_content_store_document_type: Guidance::DOCUMENT_TYPES,
           fields: %w[title link],
         )['results']
+
+        results.map do |result|
+          {
+            title: result['title'],
+            link: result['link'],
+          }
+        end
       rescue StandardError => e
         GovukNavigationHelpers.configuration.error_handler.notify(e)
         []

--- a/spec/taxonomy_sidebar_spec.rb
+++ b/spec/taxonomy_sidebar_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe GovukNavigationHelpers::TaxonomySidebar do
                   description: "The 1st taxon.",
                   related_content: [
                     {
-                      "title" => 'Result Content',
-                      "link" => '/result-content',
+                      title: 'Result Content',
+                      link: '/result-content',
                     },
                   ],
                 },
@@ -65,8 +65,8 @@ RSpec.describe GovukNavigationHelpers::TaxonomySidebar do
                   description: "The 2nd taxon.",
                   related_content: [
                     {
-                      "title" => 'Result Content',
-                      "link" => '/result-content',
+                      title: 'Result Content',
+                      link: '/result-content',
                     },
                   ],
                 },


### PR DESCRIPTION
Govuk Components requires symbol keys.


### Trello 


https://trello.com/c/EJXC60k1/429-add-more-like-this-results-to-side-navigation-in-frontend-apps
