### PR TITLE
Remove sections from taxonomy sidebar response

### DIFF
--- a/lib/govuk_navigation_helpers/taxonomy_sidebar.rb
+++ b/lib/govuk_navigation_helpers/taxonomy_sidebar.rb
@@ -10,7 +10,7 @@ module GovukNavigationHelpers
 
     def sidebar
       {
-        sections: taxons.any? ? [{ title: "More about #{@content_item.title}", items: taxons }] : []
+        items: taxons
       }
     end
 

--- a/spec/taxonomy_sidebar_spec.rb
+++ b/spec/taxonomy_sidebar_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe GovukNavigationHelpers::TaxonomySidebar do
         content_item = { "links" => {} }
 
         expect(sidebar_for(content_item)).to eq(
-          sections: []
+          items: []
         )
       end
     end
@@ -44,34 +44,29 @@ RSpec.describe GovukNavigationHelpers::TaxonomySidebar do
         content_item = content_item_tagged_to_taxon
 
         expect(sidebar_for(content_item)).to eq(
-          sections: [
+          items: [
             {
-              title: "More about A piece of content",
-              items: [
+              title: "Taxon 1",
+              url: "/taxon-1",
+              description: "The 1st taxon.",
+              related_content: [
                 {
-                  title: "Taxon 1",
-                  url: "/taxon-1",
-                  description: "The 1st taxon.",
-                  related_content: [
-                    {
-                      title: 'Result Content',
-                      link: '/result-content',
-                    },
-                  ],
-                },
-                {
-                  title: "Taxon 2",
-                  url: "/taxon-2",
-                  description: "The 2nd taxon.",
-                  related_content: [
-                    {
-                      title: 'Result Content',
-                      link: '/result-content',
-                    },
-                  ],
+                  title: 'Result Content',
+                  link: '/result-content',
                 },
               ],
-            }
+            },
+            {
+              title: "Taxon 2",
+              url: "/taxon-2",
+              description: "The 2nd taxon.",
+              related_content: [
+                {
+                  title: 'Result Content',
+                  link: '/result-content',
+                },
+              ],
+            },
           ]
         )
       end


### PR DESCRIPTION
The data structure returned by the taxonomy sidebar helper is unnecessarily nested, and the notion of "sections" does not map to our usage (it would always be an array of 1 item, with a title that repeats the current content title).

NB: This is an API-breaking change, so should get a major version bump.

### Trello

https://trello.com/c/EJXC60k1/429-add-more-like-this-results-to-side-navigation-in-frontend-apps