### PR TITLE
Only show 3 related links on taxonomy sidebar

### DIFF
--- a/lib/govuk_navigation_helpers/taxonomy_sidebar.rb
+++ b/lib/govuk_navigation_helpers/taxonomy_sidebar.rb
@@ -36,7 +36,7 @@ module GovukNavigationHelpers
         results = Services.rummager.search(
           similar_to: @content_item.base_path,
           start: 0,
-          count: 5,
+          count: 3,
           filter_taxons: [taxon.content_id],
           filter_content_store_document_type: Guidance::DOCUMENT_TYPES,
           fields: %w[title link],


### PR DESCRIPTION
This has been used in research and should be the default.