### PR TITLE
Sort parent taxons before selecting the first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Sort parent taxons by title before picking the first one for the breadcrumbs.
+
 ## 3.0.1
 
 * Return only 3 related items for the taxonomy sidebar.

--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -20,7 +20,7 @@ module GovukNavigationHelpers
     def parent_taxon
       # TODO: Determine what to do when there are multiple taxons/parents. For
       # now just display the first of each.
-      parent_taxons.first
+      parent_taxons.sort_by(&:title).first
     end
 
     def parent_taxons

--- a/spec/taxon_breadcrumbs_spec.rb
+++ b/spec/taxon_breadcrumbs_spec.rb
@@ -98,6 +98,40 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
         )
       end
     end
+
+    context 'with multiple parents' do
+      it "selects the first parent taxon in alphabetical order by title" do
+        parent_1 = {
+            "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+            "locale" => "en",
+            "title" => "Parent A",
+            "base_path" => "/parent-a",
+            "links" => {
+                "parent_taxons" => []
+            }
+        }
+        parent_2 = {
+            "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+            "locale" => "en",
+            "title" => "Parent B",
+            "base_path" => "/parent-b",
+            "links" => {
+                "parent_taxons" => []
+            }
+        }
+
+        content_item = taxon_with_parent_taxons([parent_2, parent_1])
+        breadcrumbs = breadcrumbs_for(content_item)
+
+        expect(breadcrumbs).to eq(
+          breadcrumbs: [
+            { title: "Home", url: "/" },
+            { title: "Parent A", url: "/parent-a" },
+            { title: "Taxon", is_current_page: true },
+          ]
+        )
+      end
+    end
   end
 
   def breadcrumbs_for(content_item)


### PR DESCRIPTION
This commit makes sure parent taxons are sorted alphabetically by title
before we select the first one to use. This is for consistency reasons
until we have a way of modelling parent taxons.

Trello: https://trello.com/c/RLWfiG6N/481-make-breadcrumb-use-1st-alphabetic-topic