### PR TITLE
Statsd metric tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ This gem allows the configuration of:
 
 - an error handler class (e.g. `Airbrake`), that implements a `notify` method
   which takes an exception object (by default, it prints the exception to stdout
-  when not configured).
+  when not configured);
+- a statsd client - when not configured, it does not do anything. This client
+  should implement `increment(metric)` and `time(metric, &block)`.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ And then execute:
 
     $ bundle
 
+### Configuration
+
+This gem allows the configuration of:
+
+- an error handler class (e.g. `Airbrake`), that implements a `notify` method
+  which takes an exception object (by default, it prints the exception to stdout
+  when not configured).
+
 ### Usage
 
 Get the JSON representation of a page and initialise the helper:

--- a/lib/govuk_navigation_helpers/configuration.rb
+++ b/lib/govuk_navigation_helpers/configuration.rb
@@ -8,14 +8,23 @@ module GovukNavigationHelpers
   end
 
   class Configuration
-    attr_writer :error_handler
-
-    def initialize
-      @configuration = {}
-    end
+    attr_writer :error_handler, :statsd
 
     def error_handler
       @error_handler ||= NoErrorHandler.new
+    end
+
+    def statsd
+      @statsd ||= NoStatsd.new
+    end
+
+    class NoStatsd
+      def increment(*)
+      end
+
+      def time(*)
+        yield
+      end
     end
 
     class NoErrorHandler

--- a/spec/taxonomy_sidebar_spec.rb
+++ b/spec/taxonomy_sidebar_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe GovukNavigationHelpers::TaxonomySidebar do
 
     context 'given a content item tagged to taxons' do
       it 'returns a sidebar hash containing a list of parent taxons and related content' do
+        expect(GovukNavigationHelpers.configuration.statsd).to receive(
+          :increment
+        ).with(
+          :taxonomy_sidebar_searches
+        ).twice
+
         content_item = content_item_tagged_to_taxon
 
         expect(sidebar_for(content_item)).to eq(
@@ -84,6 +90,10 @@ RSpec.describe GovukNavigationHelpers::TaxonomySidebar do
         GovukNavigationHelpers.configure do |config|
           config.error_handler = error_handler
         end
+
+        expect(GovukNavigationHelpers.configuration.statsd).to_not receive(
+          :increment
+        )
       end
 
       it 'does not re-raise' do


### PR DESCRIPTION
This commit allows the gem to be configured with a statsd client, which
can be used to track counts and timings of the search queries.

When nothing is passed in, a no-op client will be used instead.

Trello: https://trello.com/c/S72dddmO/488-configure-navigation-helpers-with-statsd