### PR TITLE
Remove `notice` from guidance document types

### DIFF
--- a/lib/govuk_navigation_helpers/guidance.rb
+++ b/lib/govuk_navigation_helpers/guidance.rb
@@ -16,7 +16,6 @@ module GovukNavigationHelpers
       local_transaction
       manual
       map
-      notice
       place
       programme
       promotional


### PR DESCRIPTION
After looking at the `notice` content which has been tagged to taxons, we've decided that it shouldn't appear on taxonomy navigation pages.

Trello: https://trello.com/c/RhEocgyj/42-remove-notices-from-guidance-list

I'm going to make the same change in [govuk_document_types|github.com/alphagov/govuk_document_types].