### PR TITLE
Release version 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.1
+
+* Remove `notice` from list of guidance document types.
+
 ## 3.1.0
 
 * Allow a statsd client to be passed in via configuration options. This will

--- a/lib/govuk_navigation_helpers/version.rb
+++ b/lib/govuk_navigation_helpers/version.rb
@@ -1,3 +1,3 @@
 module GovukNavigationHelpers
-  VERSION = "3.1.0".freeze
+  VERSION = "3.1.1".freeze
 end


### PR DESCRIPTION
https://trello.com/c/RhEocgyj/42-remove-notices-from-guidance-list