### PR TITLE
Identify parent taxon in breadcrumb helper

### DIFF
--- a/lib/govuk_navigation_helpers/taxon_breadcrumbs.rb
+++ b/lib/govuk_navigation_helpers/taxon_breadcrumbs.rb
@@ -5,11 +5,18 @@ module GovukNavigationHelpers
     end
 
     def breadcrumbs
-      ordered_parents = all_parents.map do |parent|
-        { title: parent.title, url: parent.base_path }
+      ordered_parents = all_parents.map.with_index do |parent, index|
+        {
+          title: parent.title,
+          url: parent.base_path,
+          is_page_parent: index == 0
+        }
       end
 
-      ordered_parents << { title: "Home", url: "/" }
+      ordered_parents << {
+        title: "Home",
+        url: "/",
+        is_page_parent: ordered_parents.empty? }
 
       ordered_breadcrumbs = ordered_parents.reverse
       ordered_breadcrumbs << { title: content_item.title, is_current_page: true }

--- a/spec/taxon_breadcrumbs_spec.rb
+++ b/spec/taxon_breadcrumbs_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
 
       expect(breadcrumbs).to eq(
         breadcrumbs: [
-          { title: "Home", url: "/" },
+          { title: "Home", url: "/", is_page_parent: true },
           { title: "Some Content", is_current_page: true }
         ]
       )
@@ -33,8 +33,8 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
 
       expect(breadcrumbs).to eq(
         breadcrumbs: [
-          { title: "Home", url: "/" },
-          { title: "Taxon", url: "/taxon" },
+          { title: "Home", url: "/", is_page_parent: false },
+          { title: "Taxon", url: "/taxon", is_page_parent: true },
           { title: "Some Content", is_current_page: true },
         ]
       )
@@ -64,10 +64,10 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
 
         expect(breadcrumbs).to eq(
           breadcrumbs: [
-            { title: "Home", url: "/" },
-            { title: "Another-parent", url: "/another-parent" },
-            { title: "A-parent", url: "/a-parent" },
-            { title: "Taxon", url: "/taxon" },
+            { title: "Home", url: "/", is_page_parent: false },
+            { title: "Another-parent", url: "/another-parent", is_page_parent: false },
+            { title: "A-parent", url: "/a-parent", is_page_parent: false },
+            { title: "Taxon", url: "/taxon", is_page_parent: true },
             { title: "Some Content", is_current_page: true },
           ]
         )
@@ -91,8 +91,8 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
 
         expect(breadcrumbs).to eq(
           breadcrumbs: [
-            { title: "Home", url: "/" },
-            { title: "A-parent", url: "/a-parent" },
+            { title: "Home", url: "/", is_page_parent: false },
+            { title: "A-parent", url: "/a-parent", is_page_parent: true },
             { title: "Taxon", is_current_page: true },
           ]
         )
@@ -125,8 +125,8 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
 
         expect(breadcrumbs).to eq(
           breadcrumbs: [
-            { title: "Home", url: "/" },
-            { title: "Parent A", url: "/parent-a" },
+            { title: "Home", url: "/", is_page_parent: false },
+            { title: "Parent A", url: "/parent-a", is_page_parent: true },
             { title: "Taxon", is_current_page: true },
           ]
         )


### PR DESCRIPTION
This will allow the breadcrumb component in static to collapse the breadcrumbs to just the parent taxon in the mobile view.

https://trello.com/c/Y7OirowB/472-mobile-version-of-breadcrumbs-should-only-show-previous-link

The new flag is used in alphagov/static#948, but they can be merged in any order.