### PR TITLE
Release version 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.2.1
+
+* Add `is_page_parent` flag to the breadcrumb which is the direct parent of the
+  current taxon.
+
 ## 3.2.0
 
 * Alphabetically sort taxons and related links in the taxonomy sidebar.

--- a/lib/govuk_navigation_helpers/version.rb
+++ b/lib/govuk_navigation_helpers/version.rb
@@ -1,3 +1,3 @@
 module GovukNavigationHelpers
-  VERSION = "3.2.0".freeze
+  VERSION = "3.2.1".freeze
 end


### PR DESCRIPTION
https://trello.com/c/Y7OirowB/472-mobile-version-of-breadcrumbs-should-only-show-previous-link