### PR TITLE
Release version 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 4.0.0
+
+* **BREAKING CHANGE**: remove `Guidance::DOCUMENT_TYPES`. Clients should use
+  filter guidance content using the `navigation_document_supertype` field which
+  has been added to search and the content store.
+* Use `navigation_document_supertype` internally in search queries to find
+  guidance content.
+
 ## 3.2.1
 
 * Add `is_page_parent` flag to the breadcrumb which is the direct parent of the

--- a/lib/govuk_navigation_helpers/version.rb
+++ b/lib/govuk_navigation_helpers/version.rb
@@ -1,3 +1,3 @@
 module GovukNavigationHelpers
-  VERSION = "3.2.1".freeze
+  VERSION = "4.0.0".freeze
 end


### PR DESCRIPTION
I've bumped the major version number because this is technically a breaking change (removing `Guidance::DOCUMENT_TYPES`. Is that the right thing to do in this library?