### PR TITLE
Pass document type into taxon breadcrumbs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,16 +1,9 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
-require "gem_publisher"
 
 RSpec::Core::RakeTask.new(:spec)
 
 task default: [:spec, :lint]
-
-desc "Publish gem to RubyGems"
-task :publish_gem do |_t|
-  published_gem = GemPublisher.publish_if_updated("govuk_navigation_helpers.gemspec", :rubygems)
-  puts "Published #{published_gem}" if published_gem
-end
 
 desc "Run govuk-lint with similar params to CI"
 task "lint" do

--- a/govuk_navigation_helpers.gemspec
+++ b/govuk_navigation_helpers.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.5"
-  spec.add_development_dependency "gem_publisher", "~> 1.5.0"
   spec.add_development_dependency "govuk-lint", "~> 1.2.1"
   spec.add_development_dependency "pry-byebug", "~> 3.4"
   spec.add_development_dependency "yard", "~> 0.8"

--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -65,5 +65,9 @@ module GovukNavigationHelpers
     def external_links
       content_store_response.dig("details", "external_related_links").to_a
     end
+
+    def document_type
+      content_store_response.fetch("document_type")
+    end
   end
 end

--- a/lib/govuk_navigation_helpers/taxon_breadcrumbs.rb
+++ b/lib/govuk_navigation_helpers/taxon_breadcrumbs.rb
@@ -9,17 +9,23 @@ module GovukNavigationHelpers
         {
           title: parent.title,
           url: parent.base_path,
-          is_page_parent: index == 0
+          document_type: parent.document_type,
+          is_page_parent: index == 0,
         }
       end
 
       ordered_parents << {
         title: "Home",
         url: "/",
-        is_page_parent: ordered_parents.empty? }
+        is_page_parent: ordered_parents.empty?,
+      }
 
       ordered_breadcrumbs = ordered_parents.reverse
-      ordered_breadcrumbs << { title: content_item.title, is_current_page: true }
+      ordered_breadcrumbs << {
+        title: content_item.title,
+        document_type: content_item.document_type,
+        is_current_page: true,
+      }
 
       {
         breadcrumbs: ordered_breadcrumbs

--- a/spec/taxon_breadcrumbs_spec.rb
+++ b/spec/taxon_breadcrumbs_spec.rb
@@ -21,8 +21,16 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
 
       expect(breadcrumbs).to eq(
         breadcrumbs: [
-          { title: "Home", url: "/", is_page_parent: true },
-          { title: "Some Content", is_current_page: true }
+          {
+            title: "Home",
+            url: "/",
+            is_page_parent: true
+          },
+          {
+            title: "Some Content",
+            document_type: "guidance",
+            is_current_page: true
+          },
         ]
       )
     end
@@ -33,9 +41,22 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
 
       expect(breadcrumbs).to eq(
         breadcrumbs: [
-          { title: "Home", url: "/", is_page_parent: false },
-          { title: "Taxon", url: "/taxon", is_page_parent: true },
-          { title: "Some Content", is_current_page: true },
+          {
+            title: "Home",
+            url: "/",
+            is_page_parent: false,
+          },
+          {
+            title: "Taxon",
+            url: "/taxon",
+            document_type: "taxon",
+            is_page_parent: true,
+          },
+          {
+            title: "Some Content",
+            document_type: "guidance",
+            is_current_page: true,
+          },
         ]
       )
     end
@@ -46,6 +67,7 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
             "title" => "Another-parent",
             "base_path" => "/another-parent",
             "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+            "document_type" => "taxon",
             "locale" => "en",
         }
 
@@ -54,6 +76,7 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
             "locale" => "en",
             "title" => "A-parent",
             "base_path" => "/a-parent",
+            "document_type" => "taxon",
             "links" => {
                 "parent_taxons" => [grandparent]
             }
@@ -64,11 +87,34 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
 
         expect(breadcrumbs).to eq(
           breadcrumbs: [
-            { title: "Home", url: "/", is_page_parent: false },
-            { title: "Another-parent", url: "/another-parent", is_page_parent: false },
-            { title: "A-parent", url: "/a-parent", is_page_parent: false },
-            { title: "Taxon", url: "/taxon", is_page_parent: true },
-            { title: "Some Content", is_current_page: true },
+            {
+              title: "Home",
+              url: "/",
+              is_page_parent: false,
+            },
+            {
+              title: "Another-parent",
+              url: "/another-parent",
+              document_type: "taxon",
+              is_page_parent: false,
+            },
+            {
+              title: "A-parent",
+              url: "/a-parent",
+              document_type: "taxon",
+              is_page_parent: false,
+            },
+            {
+              title: "Taxon",
+              url: "/taxon",
+              document_type: "taxon",
+              is_page_parent: true,
+            },
+            {
+              title: "Some Content",
+              document_type: "guidance",
+              is_current_page: true,
+            },
           ]
         )
       end
@@ -81,6 +127,7 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
             "locale" => "en",
             "title" => "A-parent",
             "base_path" => "/a-parent",
+            "document_type" => "taxon",
             "links" => {
                 "parent_taxons" => []
             }
@@ -91,9 +138,22 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
 
         expect(breadcrumbs).to eq(
           breadcrumbs: [
-            { title: "Home", url: "/", is_page_parent: false },
-            { title: "A-parent", url: "/a-parent", is_page_parent: true },
-            { title: "Taxon", is_current_page: true },
+            {
+              title: "Home",
+              url: "/",
+              is_page_parent: false,
+            },
+            {
+              title: "A-parent",
+              url: "/a-parent",
+              document_type: "taxon",
+              is_page_parent: true,
+            },
+            {
+              title: "Taxon",
+              document_type: "taxon",
+              is_current_page: true,
+            },
           ]
         )
       end
@@ -106,6 +166,7 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
             "locale" => "en",
             "title" => "Parent A",
             "base_path" => "/parent-a",
+            "document_type" => "taxon",
             "links" => {
                 "parent_taxons" => []
             }
@@ -115,6 +176,7 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
             "locale" => "en",
             "title" => "Parent B",
             "base_path" => "/parent-b",
+            "document_type" => "taxon",
             "links" => {
                 "parent_taxons" => []
             }
@@ -125,9 +187,22 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
 
         expect(breadcrumbs).to eq(
           breadcrumbs: [
-            { title: "Home", url: "/", is_page_parent: false },
-            { title: "Parent A", url: "/parent-a", is_page_parent: true },
-            { title: "Taxon", is_current_page: true },
+            {
+              title: "Home",
+              url: "/",
+              is_page_parent: false,
+            },
+            {
+              title: "Parent A",
+              url: "/parent-a",
+              document_type: "taxon",
+              is_page_parent: true,
+            },
+            {
+              title: "Taxon",
+              document_type: "taxon",
+              is_current_page: true,
+            },
           ]
         )
       end
@@ -135,6 +210,7 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
   end
 
   def breadcrumbs_for(content_item)
+    content_item["document_type"] ||= "guidance"
     generator = GovukSchemas::RandomExample.for_schema("taxon", schema_type: "frontend")
     fully_valid_content_item = generator.merge_and_validate(content_item)
 
@@ -164,6 +240,7 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
             "locale" => "en",
             "title" => "Taxon",
             "base_path" => "/taxon",
+            "document_type" => "taxon",
             "links" => {
               "parent_taxons" => parents
             },


### PR DESCRIPTION
As part of our tracking work, we will be reporting information about
the taxonomy of the current document. This information must be kept
consistent with the breadcrumbs, so it makes the most sense to track it
from the breadcrumb component.
This tracking logic requires knowledge of which is the highest, and
lowest taxon in the breadcrumb list, which can be achieved by passing
the document type into the breadcrumbs.

### Trello

https://trello.com/c/6lLHmlEe/495-track-the-theme-and-taxon-of-content-items