### PR TITLE
Limit related links to first 2 taxons in sidebar

### DIFF
--- a/lib/govuk_navigation_helpers/taxonomy_sidebar.rb
+++ b/lib/govuk_navigation_helpers/taxonomy_sidebar.rb
@@ -21,12 +21,15 @@ module GovukNavigationHelpers
 
     def taxons
       parent_taxons = @content_item.parent_taxons
-      parent_taxons.map do |parent_taxon|
+
+      parent_taxons.each_with_index.map do |parent_taxon, index|
+        related_content = index < 2 ? content_related_to(parent_taxon) : []
+
         {
           title: parent_taxon.title,
           url: parent_taxon.base_path,
           description: parent_taxon.description,
-          related_content: content_related_to(parent_taxon),
+          related_content: related_content,
         }
       end
     end

--- a/spec/taxonomy_sidebar_spec.rb
+++ b/spec/taxonomy_sidebar_spec.rb
@@ -75,6 +75,54 @@ RSpec.describe GovukNavigationHelpers::TaxonomySidebar do
           ]
         )
       end
+
+      it 'only shows related links for the first 2 taxons with related content' do
+        expect(GovukNavigationHelpers.configuration.statsd).to receive(
+          :increment
+        ).with(
+          :taxonomy_sidebar_searches
+        ).twice
+
+        content_item = content_item_tagged_to_taxon
+
+        content_item['links']['taxons'] << {
+          "title" => "Taxon C",
+          "base_path" => "/taxon-c",
+          "content_id" => "taxon-c",
+          "description" => "The C taxon."
+        }
+
+        expect(sidebar_for(content_item)).to eq(
+          items: [
+            {
+              title: "Taxon A",
+              url: "/taxon-a",
+              description: "The A taxon.",
+              related_content: [
+                { 'title': 'Related item A', 'link': '/related-item-a', },
+                { 'title': 'Related item B', 'link': '/related-item-b', },
+                { 'title': 'Related item C', 'link': '/related-item-c', },
+              ],
+            },
+            {
+              title: "Taxon B",
+              url: "/taxon-b",
+              description: "The B taxon.",
+              related_content: [
+                { 'title': 'Related item A', 'link': '/related-item-a', },
+                { 'title': 'Related item B', 'link': '/related-item-b', },
+                { 'title': 'Related item C', 'link': '/related-item-c', },
+              ],
+            },
+            {
+              title: "Taxon C",
+              url: "/taxon-c",
+              description: "The C taxon.",
+              related_content: [],
+            },
+          ]
+        )
+      end
     end
 
     context 'when Rummager raises an exception' do


### PR DESCRIPTION
This is not a new feature. It used to be done in [static](https://github.com/alphagov/static/blob/master/app/views/govuk_component/taxonomy_sidebar.raw.html.erb#L31). That is problematic for a number of reasons:

- we might be making calls to the search API that won't get used in the
  frontend apps. An example of this is when a piece of content is tagged
  to more than 2 taxons. We would be making an API call for each of the
  taxons, but only displaying the results of the first 2;
- we will want to display curated related links underneath the taxonomy
  links. Again, if a content item is tagged to more than 2 taxons, we
  wouldn't be displaying links for sections such as "Elsewhere on
  GOV.UK".

After this change is live, we can remove the equivalent functionality in
static.

Trello: https://trello.com/c/vM6Kaw9B/546-ias-and-content-designers-can-curate-related-links-for-any-content-type