### PR TITLE
Update the gds-api-adapters gem

### DIFF
--- a/govuk_navigation_helpers.gemspec
+++ b/govuk_navigation_helpers.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "gds-api-adapters", "~> 40.1"
+  spec.add_runtime_dependency "gds-api-adapters", "~> 41.0"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Use the latest version of gds-api-adapters, which has had a major version number increase.

The new version renames the `GOVUK_FACT_CHECK_ID` header to `GOVUK_AUTH_BYPASS_ID` in the middleware.

Trello: https://trello.com/c/u1H1rgDA/525-some-finding-pages-are-still-being-tracked-as-thing

This will let us bump the gds-api-adapters version number on projects which depend on both that project and govuk_navigation_helpers.