### PR TITLE
Include curated and external links in sidebar

### DIFF
--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -62,6 +62,12 @@ module GovukNavigationHelpers
       end
     end
 
+    def related_overrides
+      content_store_response.dig("links", "ordered_related_items_overrides").to_a.map do |link|
+        ContentItem.new(link)
+      end
+    end
+
     def external_links
       content_store_response.dig("details", "external_related_links").to_a
     end

--- a/lib/govuk_navigation_helpers/taxonomy_sidebar.rb
+++ b/lib/govuk_navigation_helpers/taxonomy_sidebar.rb
@@ -9,7 +9,7 @@ module GovukNavigationHelpers
 
     def sidebar
       {
-        items: taxons
+        items: [taxons, elsewhere_on_govuk, elsewhere_on_the_web].flatten
       }
     end
 
@@ -34,9 +34,46 @@ module GovukNavigationHelpers
       end
     end
 
-    # This method will fetch content related to @content_item, and tagged to taxon. This is a
-    # temporary method that uses search to achieve this. This behaviour is to be moved into
-    # the content store
+    def elsewhere_on_govuk
+      return [] if @content_item.related_overrides.empty?
+
+      related_content = @content_item.related_overrides.map do |override|
+        {
+          title: override.title,
+          link: override.base_path
+        }
+      end
+
+      [
+        {
+          title: "Elsewhere on GOV.UK",
+          related_content: related_content
+        }
+      ]
+    end
+
+    def elsewhere_on_the_web
+      return [] if @content_item.external_links.empty?
+
+      related_content = @content_item.external_links.map do |external_link|
+        {
+          title: external_link.fetch('title'),
+          link: external_link.fetch('url'),
+          rel: 'external'
+        }
+      end
+
+      [
+        {
+          title: "Elsewhere on the web",
+          related_content: related_content
+        }
+      ]
+    end
+
+    # This method will fetch content related to @content_item, and tagged to
+    # taxon. This is a temporary method that uses search to achieve this. This
+    # behaviour is to be moved into the content store.
     def content_related_to(taxon)
       statsd.time(:taxonomy_sidebar_search_time) do
         begin

--- a/spec/taxonomy_sidebar_spec.rb
+++ b/spec/taxonomy_sidebar_spec.rb
@@ -123,6 +123,48 @@ RSpec.describe GovukNavigationHelpers::TaxonomySidebar do
           ]
         )
       end
+
+      it "includes curated and external links when available" do
+        expect(GovukNavigationHelpers.configuration.statsd).to receive(
+          :increment
+        ).with(
+          :taxonomy_sidebar_searches
+        ).once
+
+        content_item =
+          content_item_tagged_to_taxon_with_curated_and_external_links
+
+        expect(sidebar_for(content_item)).to eq(
+          items: [
+            {
+              title: "Taxon A",
+              url: "/taxon-a",
+              description: "The A taxon.",
+              related_content: [
+                { 'title': 'Related item A', 'link': '/related-item-a', },
+                { 'title': 'Related item B', 'link': '/related-item-b', },
+                { 'title': 'Related item C', 'link': '/related-item-c', },
+              ],
+            },
+            {
+              title: "Elsewhere on GOV.UK",
+              related_content: [
+                { title: "Curated link 1", link: "/curated-link-1" }
+              ]
+            },
+            {
+              title: "Elsewhere on the web",
+              related_content: [
+                {
+                  title: "An external link",
+                  link: "www.external-link.com",
+                  rel: "external"
+                }
+              ]
+            }
+          ]
+        )
+      end
     end
 
     context 'when Rummager raises an exception' do
@@ -182,6 +224,34 @@ RSpec.describe GovukNavigationHelpers::TaxonomySidebar do
           },
         ],
       },
+    }
+  end
+
+  def content_item_tagged_to_taxon_with_curated_and_external_links
+    {
+      "title" => "A piece of content",
+      "base_path" => "/a-piece-of-content",
+      "links" => {
+        "taxons" => [
+          {
+            "title" => "Taxon A",
+            "base_path" => "/taxon-a",
+            "content_id" => "taxon-a",
+            "description" => "The A taxon.",
+          }
+        ],
+        "ordered_related_items_overrides" => [
+          "title" => "Curated link 1",
+          "base_path" => "/curated-link-1",
+          "content_id" => "curated-link-1",
+        ]
+      },
+      "details" => {
+        "external_related_links" => [
+          "url" => "www.external-link.com",
+          "title" => "An external link"
+        ]
+      }
     }
   end
 end


### PR DESCRIPTION
This commit adds both curated and external related links to the taxonomy
sidebar. This will allow us to show the new taxonomy sidebar for some
mainstream content where we manually show the old related links.

This commit will allow us to revert
https://github.com/alphagov/frontend/commit/02b6ad2b2825c61daeca469836e6917f3b9032fd

Here is an example page with all 3 sections: https://www.gov.uk/api/content/student-finance

And it will look like this:

<img width="819" alt="screen shot 2017-03-23 at 12 53 56" src="https://cloud.githubusercontent.com/assets/416701/24257199/130323d2-0fe2-11e7-8c5b-71189ef3e336.png">

Trello: https://trello.com/c/vM6Kaw9B/546-ias-and-content-designers-can-curate-related-links-for-any-content-type