### PR TITLE
Release version 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 5.0.0
+
+* **BREAKING CHANGE**: Update the gds-api-adapters gem. This includes a change
+  which replaces the `GOVUK-Fact-Check-Id` header with the
+  `GOVUK-Auth-Bypass-Id` header when passing on requests from the client to
+  APIs. See the gds-api-adapters changelog for more information on upgrading.
+* Limit related links to the first two taxons.
+
 ## 4.0.0
 
 * **BREAKING CHANGE**: remove `Guidance::DOCUMENT_TYPES`. Clients should use

--- a/lib/govuk_navigation_helpers/version.rb
+++ b/lib/govuk_navigation_helpers/version.rb
@@ -1,3 +1,3 @@
 module GovukNavigationHelpers
-  VERSION = "4.0.0".freeze
+  VERSION = "5.0.0".freeze
 end


### PR DESCRIPTION
Increase the major version number because the gds-api-adapters gem update changes the headers added by the Rails middleware which will affect how content store changes are linked to admin users. This means that upgrading to this version should not be done silently with a minor version increase.

https://trello.com/c/u1H1rgDA/525-some-finding-pages-are-still-being-tracked-as-thing