### PR TITLE
[DO NOT MERGE] Allow for curated related links under taxons

### DIFF
--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -40,6 +40,20 @@ module GovukNavigationHelpers
       end
     end
 
+    def taxons
+      content_store_response.dig("links", "taxons").to_a.map do |link|
+        ContentItem.new(link)
+      end
+    end
+
+    def taxon_base_paths
+      taxons.map(&:base_path)
+    end
+
+    def tagged_to_taxon?(taxon_base_path)
+      taxon_base_paths.include?(taxon_base_path)
+    end
+
     def title
       content_store_response.fetch("title")
     end
@@ -62,9 +76,24 @@ module GovukNavigationHelpers
       end
     end
 
-    def related_overrides
+    def curated_related_links
+      # TODO: rename the fiel in the schemas
       content_store_response.dig("links", "ordered_related_items_overrides").to_a.map do |link|
         ContentItem.new(link)
+      end
+    end
+
+    def curated_related_links_for_taxon(taxon)
+      return [] if curated_related_links.empty?
+
+      curated_related_links.select do |curated_related_link|
+        curated_related_link.tagged_to_taxon?(taxon.base_path)
+      end
+    end
+
+    def curated_related_links_elsewhere_on_govuk
+      curated_related_links.select do |curated_related_link|
+        (curated_related_link.taxon_base_paths & taxon_base_paths).empty?
       end
     end
 

--- a/spec/taxonomy_sidebar_spec.rb
+++ b/spec/taxonomy_sidebar_spec.rb
@@ -165,6 +165,45 @@ RSpec.describe GovukNavigationHelpers::TaxonomySidebar do
           ]
         )
       end
+
+      it "includes curated related links grouped per taxon when available" do
+        expect(GovukNavigationHelpers.configuration.statsd).to receive(
+          :increment
+        ).with(
+          :taxonomy_sidebar_searches
+        ).once
+
+        content_item = content_item_and_curated_links_tagged_to_same_taxon
+
+        expect(sidebar_for(content_item)).to eq(
+          items: [
+            {
+              title: "Taxon A",
+              url: "/taxon-a",
+              description: "The A taxon.",
+              related_content: [
+                { title: "Curated link 1", link: "/curated-link-1" }
+              ],
+            },
+            {
+              title: "Taxon B",
+              url: "/taxon-b",
+              description: "The B taxon.",
+              related_content: [
+                { 'title': 'Related item A', 'link': '/related-item-a', },
+                { 'title': 'Related item B', 'link': '/related-item-b', },
+                { 'title': 'Related item C', 'link': '/related-item-c', },
+              ],
+            },
+            {
+              title: "Elsewhere on GOV.UK",
+              related_content: [
+                { title: "Curated link 2", link: "/curated-link-2" }
+              ]
+            },
+          ]
+        )
+      end
     end
 
     context 'when Rummager raises an exception' do
@@ -250,6 +289,54 @@ RSpec.describe GovukNavigationHelpers::TaxonomySidebar do
         "external_related_links" => [
           "url" => "www.external-link.com",
           "title" => "An external link"
+        ]
+      }
+    }
+  end
+
+  def content_item_and_curated_links_tagged_to_same_taxon
+    {
+      "title" => "A piece of content",
+      "base_path" => "/a-piece-of-content",
+      "links" => {
+        "taxons" => [
+          {
+            "title" => "Taxon A",
+            "base_path" => "/taxon-a",
+            "content_id" => "taxon-a",
+            "description" => "The A taxon.",
+          },
+          {
+            "title" => "Taxon B",
+            "base_path" => "/taxon-b",
+            "content_id" => "taxon-b",
+            "description" => "The B taxon.",
+          },
+        ],
+        "ordered_related_items_overrides" => [
+          {
+            "title" => "Curated link 1",
+            "base_path" => "/curated-link-1",
+            "content_id" => "curated-link-1",
+            "links" => {
+              "taxons" => [
+                {
+                  "title" => "Taxon A",
+                  "base_path" => "/taxon-a",
+                  "content_id" => "taxon-a",
+                  "description" => "The A taxon.",
+                }
+              ],
+            }
+          },
+          {
+            "title" => "Curated link 2",
+            "base_path" => "/curated-link-2",
+            "content_id" => "curated-link-2",
+            "links" => {
+              "taxons" => [],
+            }
+          }
         ]
       }
     }


### PR DESCRIPTION
**NOTE**: this needs product feedback before it can be merged.

This commit changes how we display the curated related links on the new
taxonomy sidebar.

The new workflow is as follows:
- when there are no curated related links, we show similar search
  results for the first 2 taxons in the sidebar (3 links per taxon);
- when curated related links are available, we group them by taxon and
  include them in the corresponding taxon (without limit on the number
  of the links);
- if any curated related link is tagged to a different taxon than the
  taxons on the content item, we then display those links under the
  "Elsewhere on GOV.UK";
- finally, any external related links are shown under "Elsewhere on the
  web".

Trello: https://trello.com/c/vM6Kaw9B/546-ias-and-content-designers-can-curate-related-links-for-any-content-type