### PR TITLE
Upgrade gds-api-adapters to 42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Bump gds-api-adapters to 42.2, which makes `lgil` mandatory when requesting
+links from Local Links Manager.
+
 ## 5.1.0
 
 * Display Elsewhere in GOV.UK and Elsewhere on the web related links on new

--- a/govuk_navigation_helpers.gemspec
+++ b/govuk_navigation_helpers.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "gds-api-adapters", "~> 41.0"
+  spec.add_runtime_dependency "gds-api-adapters", "~> 42.0"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
The new version of the gem gds-api-adapters now makes lgil mandatory when requesting links from Local Links Manager, so Frontend needs to be using that version (42.0.0). 

In order to do that, we need to upgrade govuk_navigation_helpers from depending on gds-api-adapters 41.0 to 42.0.

https://trello.com/c/jk9mNWop/46-upgrade-frontend-to-gds-api-adapters-42-0-0