### PR TITLE
Bump to 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-## Unreleased
+## 6.0.0
 
-* Bump gds-api-adapters to 42.2, which makes `lgil` mandatory when requesting
-links from Local Links Manager.
+* **BREAKING CHANGE**: Bump gds-api-adapters to 42.2, which makes `lgil`
+mandatory when requesting links from Local Links Manager.
 
 ## 5.1.0
 

--- a/lib/govuk_navigation_helpers/version.rb
+++ b/lib/govuk_navigation_helpers/version.rb
@@ -1,3 +1,3 @@
 module GovukNavigationHelpers
-  VERSION = "5.1.0".freeze
+  VERSION = "6.0.0".freeze
 end


### PR DESCRIPTION
Upgrades gds-api-adapters to 42.2.0, which contains breaking changes
(https://github.com/alphagov/gds-api-adapters/blob/master/CHANGELOG.md#4200),
hence the major bump.