### PR TITLE
Remove duplicated related links

### DIFF
--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -62,12 +62,6 @@ module GovukNavigationHelpers
       end
     end
 
-    def related_overrides
-      content_store_response.dig("links", "ordered_related_items_overrides").to_a.map do |link|
-        ContentItem.new(link)
-      end
-    end
-
     def external_links
       content_store_response.dig("details", "external_related_links").to_a
     end

--- a/lib/govuk_navigation_helpers/taxonomy_sidebar.rb
+++ b/lib/govuk_navigation_helpers/taxonomy_sidebar.rb
@@ -21,9 +21,14 @@ module GovukNavigationHelpers
 
     def taxons
       parent_taxons = @content_item.parent_taxons
+      used_related_links = Set.new
 
       parent_taxons.each_with_index.map do |parent_taxon, index|
-        related_content = index < 2 ? content_related_to(parent_taxon) : []
+        related_content = index < 2 ? content_related_to(parent_taxon, used_related_links) : []
+
+        used_related_links.merge(
+          related_content.map { |content| content[:link] }
+        )
 
         {
           title: parent_taxon.title,
@@ -37,7 +42,7 @@ module GovukNavigationHelpers
     # This method will fetch content related to @content_item, and tagged to taxon. This is a
     # temporary method that uses search to achieve this. This behaviour is to be moved into
     # the content store
-    def content_related_to(taxon)
+    def content_related_to(taxon, used_related_links)
       statsd.time(:taxonomy_sidebar_search_time) do
         begin
           results = Services.rummager.search(
@@ -46,6 +51,7 @@ module GovukNavigationHelpers
             count: 3,
             filter_taxons: [taxon.content_id],
             filter_navigation_document_supertype: 'guidance',
+            reject_link: used_related_links.to_a,
             fields: %w[title link],
           )['results']
 

--- a/lib/govuk_navigation_helpers/taxonomy_sidebar.rb
+++ b/lib/govuk_navigation_helpers/taxonomy_sidebar.rb
@@ -9,7 +9,7 @@ module GovukNavigationHelpers
 
     def sidebar
       {
-        items: [taxons, elsewhere_on_govuk, elsewhere_on_the_web].flatten
+        items: taxons
       }
     end
 
@@ -34,46 +34,9 @@ module GovukNavigationHelpers
       end
     end
 
-    def elsewhere_on_govuk
-      return [] if @content_item.related_overrides.empty?
-
-      related_content = @content_item.related_overrides.map do |override|
-        {
-          title: override.title,
-          link: override.base_path
-        }
-      end
-
-      [
-        {
-          title: "Elsewhere on GOV.UK",
-          related_content: related_content
-        }
-      ]
-    end
-
-    def elsewhere_on_the_web
-      return [] if @content_item.external_links.empty?
-
-      related_content = @content_item.external_links.map do |external_link|
-        {
-          title: external_link.fetch('title'),
-          link: external_link.fetch('url'),
-          rel: 'external'
-        }
-      end
-
-      [
-        {
-          title: "Elsewhere on the web",
-          related_content: related_content
-        }
-      ]
-    end
-
-    # This method will fetch content related to @content_item, and tagged to
-    # taxon. This is a temporary method that uses search to achieve this. This
-    # behaviour is to be moved into the content store.
+    # This method will fetch content related to @content_item, and tagged to taxon. This is a
+    # temporary method that uses search to achieve this. This behaviour is to be moved into
+    # the content store
     def content_related_to(taxon)
       statsd.time(:taxonomy_sidebar_search_time) do
         begin

--- a/spec/taxonomy_sidebar_spec.rb
+++ b/spec/taxonomy_sidebar_spec.rb
@@ -6,9 +6,9 @@ include GdsApi::TestHelpers::Rummager
 
 RSpec.describe GovukNavigationHelpers::TaxonomySidebar do
   describe '#sidebar' do
-    before { stub_any_rummager_search_to_return_no_results }
-
     it 'can handle any valid content item' do
+      stub_any_rummager_search_to_return_no_results
+
       generator = GovukSchemas::RandomExample.for_schema(
         'placeholder',
         schema_type: 'frontend'
@@ -120,6 +120,67 @@ RSpec.describe GovukNavigationHelpers::TaxonomySidebar do
               description: "The C taxon.",
               related_content: [],
             },
+          ]
+        )
+      end
+    end
+
+    context 'given there are repeated related links across different parent taxons' do
+      before do
+        # First taxon should have links A and B
+        stub_request(
+          :get,
+          %r{.*search.json?.*\&filter_taxons%5B%5D=taxon-a.*}
+        ).to_return(
+          body: {
+            'results': [
+              { 'title': 'Related item A', 'link': '/related-item-a', },
+              { 'title': 'Related item B', 'link': '/related-item-b', },
+            ],
+          }.to_json
+        )
+
+        # Second taxon should only return link C, and reject the other 2
+        stub_request(
+          :get,
+          %r{.*search.json?.*\&filter_taxons%5B%5D=taxon-b.*&reject_link%5B%5D=/related-item-a&reject_link%5B%5D=/related-item-b.*}
+        ).to_return(
+          body: {
+            'results': [
+              { 'title': 'Related item C', 'link': '/related-item-c', },
+            ],
+          }.to_json
+        )
+      end
+
+      it 'does not duplicate the related links across each taxon' do
+        expect(GovukNavigationHelpers.configuration.statsd).to receive(
+          :increment
+        ).with(
+          :taxonomy_sidebar_searches
+        ).twice
+
+        content_item = content_item_tagged_to_taxon
+
+        expect(sidebar_for(content_item)).to eq(
+          items: [
+            {
+              title: "Taxon A",
+              url: "/taxon-a",
+              description: "The A taxon.",
+              related_content: [
+                { 'title': 'Related item A', 'link': '/related-item-a', },
+                { 'title': 'Related item B', 'link': '/related-item-b', },
+              ],
+            },
+            {
+              title: "Taxon B",
+              url: "/taxon-b",
+              description: "The B taxon.",
+              related_content: [
+                { 'title': 'Related item C', 'link': '/related-item-c', },
+              ],
+            }
           ]
         )
       end

--- a/spec/taxonomy_sidebar_spec.rb
+++ b/spec/taxonomy_sidebar_spec.rb
@@ -123,48 +123,6 @@ RSpec.describe GovukNavigationHelpers::TaxonomySidebar do
           ]
         )
       end
-
-      it "includes curated and external links when available" do
-        expect(GovukNavigationHelpers.configuration.statsd).to receive(
-          :increment
-        ).with(
-          :taxonomy_sidebar_searches
-        ).once
-
-        content_item =
-          content_item_tagged_to_taxon_with_curated_and_external_links
-
-        expect(sidebar_for(content_item)).to eq(
-          items: [
-            {
-              title: "Taxon A",
-              url: "/taxon-a",
-              description: "The A taxon.",
-              related_content: [
-                { 'title': 'Related item A', 'link': '/related-item-a', },
-                { 'title': 'Related item B', 'link': '/related-item-b', },
-                { 'title': 'Related item C', 'link': '/related-item-c', },
-              ],
-            },
-            {
-              title: "Elsewhere on GOV.UK",
-              related_content: [
-                { title: "Curated link 1", link: "/curated-link-1" }
-              ]
-            },
-            {
-              title: "Elsewhere on the web",
-              related_content: [
-                {
-                  title: "An external link",
-                  link: "www.external-link.com",
-                  rel: "external"
-                }
-              ]
-            }
-          ]
-        )
-      end
     end
 
     context 'when Rummager raises an exception' do
@@ -224,34 +182,6 @@ RSpec.describe GovukNavigationHelpers::TaxonomySidebar do
           },
         ],
       },
-    }
-  end
-
-  def content_item_tagged_to_taxon_with_curated_and_external_links
-    {
-      "title" => "A piece of content",
-      "base_path" => "/a-piece-of-content",
-      "links" => {
-        "taxons" => [
-          {
-            "title" => "Taxon A",
-            "base_path" => "/taxon-a",
-            "content_id" => "taxon-a",
-            "description" => "The A taxon.",
-          }
-        ],
-        "ordered_related_items_overrides" => [
-          "title" => "Curated link 1",
-          "base_path" => "/curated-link-1",
-          "content_id" => "curated-link-1",
-        ]
-      },
-      "details" => {
-        "external_related_links" => [
-          "url" => "www.external-link.com",
-          "title" => "An external link"
-        ]
-      }
     }
   end
 end


### PR DESCRIPTION
In this PR, we:

- delete the curated related links and external related links from the new taxonomy, as there is still no consensus if this should be shown;
- remove duplicated related links across different taxons on the same page.

As an example, the following page has repeated links in between different taxons on the side navigation:

https://www.gov.uk/government/publications/national-curriculum-in-england-art-and-design-programmes-of-study

With this change, we prevent duplication and it will look like this (example from the navigation prototype using this change):

https://govuk-nav-prototype-pr-11.herokuapp.com/government/publications/national-curriculum-in-england-art-and-design-programmes-of-study

As you can see, there is no repetition of related links between the sidebar taxons.

Trello: https://trello.com/c/I4rs80n1/80-remove-duplicated-related-links-across-all-parent-taxons