### PR TITLE
Release version 6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.1
+
+* Remove duplicate related links from search for the new taxonomy sidebar.
+
 ## 6.0.0
 
 * **BREAKING CHANGE**: Bump gds-api-adapters to 42.2, which makes `lgil`

--- a/lib/govuk_navigation_helpers/version.rb
+++ b/lib/govuk_navigation_helpers/version.rb
@@ -1,3 +1,3 @@
 module GovukNavigationHelpers
-  VERSION = "6.0.0".freeze
+  VERSION = "6.0.1".freeze
 end


### PR DESCRIPTION
Bug fix related to duplicate related links.

Trello: https://trello.com/c/I4rs80n1/80-remove-duplicated-related-links-across-all-parent-taxons