### PR TITLE
Add "Register to Vote" section to related links

### DIFF
--- a/govuk_navigation_helpers.gemspec
+++ b/govuk_navigation_helpers.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "gds-api-adapters", ">= 43.0"
+  spec.add_runtime_dependency "activesupport"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -65,5 +65,9 @@ module GovukNavigationHelpers
     def external_links
       content_store_response.dig("details", "external_related_links").to_a
     end
+
+    def document_type
+      content_store_response.fetch('document_type')
+    end
   end
 end

--- a/lib/govuk_navigation_helpers/related_items.rb
+++ b/lib/govuk_navigation_helpers/related_items.rb
@@ -20,6 +20,7 @@ module GovukNavigationHelpers
     def related_items
       {
         sections: [
+          register_to_vote_section,
           tagged_to_same_mainstream_browse_page_section,
           parents_tagged_to_same_mainstream_browse_page_section,
           tagged_to_different_mainstream_browse_pages_section,
@@ -31,6 +32,21 @@ module GovukNavigationHelpers
   private
 
     attr_reader :content_item
+
+    def register_to_vote_section
+      return unless content_item.document_type == 'completed_transaction'
+      return if content_item.base_path =~ /register-to-vote/
+
+      {
+        title: 'Register to vote',
+        description: 'To vote in the General Election on 8 June, you need to apply to register by 11:59pm on 22 May.',
+        url: nil,
+        items: [
+          title: 'Register to vote',
+          url: '/register-to-vote'
+        ]
+      }
+    end
 
     def tagged_to_same_mainstream_browse_page_section
       return unless grouped.tagged_to_same_mainstream_browse_page.any?

--- a/lib/govuk_navigation_helpers/related_items.rb
+++ b/lib/govuk_navigation_helpers/related_items.rb
@@ -37,9 +37,7 @@ module GovukNavigationHelpers
     attr_reader :content_item
 
     def register_to_vote_section
-      return if register_to_vote_deadline_reached?
-      return unless content_item.document_type == 'completed_transaction'
-      return if content_item.base_path =~ /register-to-vote/
+      return unless should_show_register_to_vote_section?
 
       {
         title: 'Register to vote',
@@ -52,8 +50,14 @@ module GovukNavigationHelpers
       }
     end
 
-    def register_to_vote_deadline_reached?
-      Time.now >= ActiveSupport::TimeZone['London'].parse('2017-05-22T23:59:59')
+    def should_show_register_to_vote_section?
+      content_item.document_type == 'completed_transaction' &&
+        register_to_vote_on_time? &&
+        content_item.base_path !~ /register-to-vote/
+    end
+
+    def register_to_vote_on_time?
+      Time.now < ActiveSupport::TimeZone['London'].parse('2017-05-22T23:59:59')
     end
 
     def tagged_to_same_mainstream_browse_page_section

--- a/lib/govuk_navigation_helpers/related_items.rb
+++ b/lib/govuk_navigation_helpers/related_items.rb
@@ -1,3 +1,6 @@
+require 'time'
+require 'active_support/core_ext/string/zones'
+require 'active_support/values/time_zone'
 require 'govuk_navigation_helpers/grouped_related_links'
 require 'govuk_navigation_helpers/content_item'
 
@@ -34,6 +37,7 @@ module GovukNavigationHelpers
     attr_reader :content_item
 
     def register_to_vote_section
+      return if register_to_vote_deadline_reached?
       return unless content_item.document_type == 'completed_transaction'
       return if content_item.base_path =~ /register-to-vote/
 
@@ -46,6 +50,10 @@ module GovukNavigationHelpers
           url: '/register-to-vote'
         ]
       }
+    end
+
+    def register_to_vote_deadline_reached?
+      Time.now >= ActiveSupport::TimeZone['London'].parse('2017-05-22T23:59:59')
     end
 
     def tagged_to_same_mainstream_browse_page_section

--- a/spec/related_items_spec.rb
+++ b/spec/related_items_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 
 RSpec.describe GovukNavigationHelpers::RelatedItems do
-  def payload_for(content_item)
-    generator = GovukSchemas::RandomExample.for_schema("placeholder", schema_type: "frontend")
+  def payload_for(content_item, schema = "placeholder")
+    generator = GovukSchemas::RandomExample.for_schema(schema, schema_type: "frontend")
     fully_valid_content_item = generator.merge_and_validate(content_item)
     GovukNavigationHelpers::NavigationHelper.new(fully_valid_content_item).related_items
   end
@@ -261,6 +261,52 @@ RSpec.describe GovukNavigationHelpers::RelatedItems do
             ]
           },
         ]
+      )
+    end
+
+    it 'does not generate the register to vote section for /register-to-vote' do
+      content_item = {
+        "base_path" => "/register-to-vote",
+        "document_type" => "completed_transaction",
+        "links" => {},
+        "details" => {
+          "external_related_links" => [],
+          "promotion" => {
+            "category" => "organ_donor",
+            "url" => "https://www.organdonation.nhs.uk/"
+          }
+        }
+      }
+      transaction_payload = payload_for(content_item, "completed_transaction")
+
+      expect(transaction_payload).to eql(sections: [])
+    end
+
+    it 'generates the register to vote section for completed transactions with register to vote promotion' do
+      content_item = {
+        "base_path" => "/done/pay-dvla-fine",
+        "document_type" => "completed_transaction",
+        "links" => {},
+        "details" => {
+          "external_related_links" => [],
+          "promotion" => {
+            "category" => "register_to_vote",
+            "url" => "/register-to-vote"
+          }
+        }
+      }
+      transaction_payload = payload_for(content_item, "completed_transaction")
+
+      expect(transaction_payload).to eql(
+        sections: [{
+          title: "Register to vote",
+          description: "To vote in the General Election on 8 June, you need to apply to register by 11:59pm on 22 May.",
+          url: nil,
+          items: [
+            title: "Register to vote",
+            url: "/register-to-vote"
+          ]
+        }]
       )
     end
   end

--- a/spec/related_items_spec.rb
+++ b/spec/related_items_spec.rb
@@ -265,6 +265,7 @@ RSpec.describe GovukNavigationHelpers::RelatedItems do
     end
 
     it 'does not generate the register to vote section for /register-to-vote' do
+      allow(Time).to receive(:now).and_return(Time.parse('2017-05-05'))
       content_item = {
         "base_path" => "/register-to-vote",
         "document_type" => "completed_transaction",
@@ -283,6 +284,7 @@ RSpec.describe GovukNavigationHelpers::RelatedItems do
     end
 
     it 'generates the register to vote section for completed transactions with register to vote promotion' do
+      allow(Time).to receive(:now).and_return(Time.parse('2017-05-05'))
       content_item = {
         "base_path" => "/done/pay-dvla-fine",
         "document_type" => "completed_transaction",
@@ -308,6 +310,25 @@ RSpec.describe GovukNavigationHelpers::RelatedItems do
           ]
         }]
       )
+    end
+
+    it 'does not show the register to vote section after May 23rd' do
+      allow(Time).to receive(:now).and_return(Time.parse('2017-05-24'))
+      content_item = {
+        "base_path" => "/done/pay-dvla-fine",
+        "document_type" => "completed_transaction",
+        "links" => {},
+        "details" => {
+          "external_related_links" => [],
+          "promotion" => {
+            "category" => "register_to_vote",
+            "url" => "/register-to-vote"
+          }
+        }
+      }
+      transaction_payload = payload_for(content_item, "completed_transaction")
+
+      expect(transaction_payload).to eql(sections: [])
     end
   end
 end


### PR DESCRIPTION
For completed transactions with the "register_to_vote" promotion, we
should display the new section in the related links in order to
encourage people to register to vote.

Trello: https://trello.com/c/QbnidEBA/97-add-promotion-for-register-to-vote-to-transaction-done-pages

Waiting on product feedback before this should be merged.