### PR TITLE
Release a new version of govuk_navigation_helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.2.0
+
+* Remove "Register to vote" section from related links data as deadline of
+  May 23rd 2017 has passed.
+
 ## 6.1.0
 
 * Add "Register to vote" section to related links data. This will only affect

--- a/lib/govuk_navigation_helpers/version.rb
+++ b/lib/govuk_navigation_helpers/version.rb
@@ -1,3 +1,3 @@
 module GovukNavigationHelpers
-  VERSION = "6.1.0".freeze
+  VERSION = "6.2.0".freeze
 end


### PR DESCRIPTION
Updated CHANGELOG to reflect what has changed.
Trello: https://trello.com/c/Bu5TJMaG/104-remove-code-related-to-register-to-vote