### PR TITLE
Present curated taxonomy sidebar links

### DIFF
--- a/lib/govuk_navigation_helpers.rb
+++ b/lib/govuk_navigation_helpers.rb
@@ -3,6 +3,8 @@ require "govuk_navigation_helpers/breadcrumbs"
 require "govuk_navigation_helpers/related_items"
 require "govuk_navigation_helpers/taxon_breadcrumbs"
 require "govuk_navigation_helpers/taxonomy_sidebar"
+require "govuk_navigation_helpers/rummager_taxonomy_sidebar_links"
+require "govuk_navigation_helpers/curated_taxonomy_sidebar_links"
 
 module GovukNavigationHelpers
   class NavigationHelper

--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -62,8 +62,33 @@ module GovukNavigationHelpers
       end
     end
 
+    def curated_taxonomy_sidebar_links
+      content_store_response.dig("links", "ordered_related_items_overrides").to_a.map do |link|
+        ContentItem.new(link)
+      end
+    end
+
     def external_links
       content_store_response.dig("details", "external_related_links").to_a
+    end
+
+    def as_taxonomy_sidebar_link
+      {
+        title: title,
+        link: base_path,
+      }
+    end
+
+    def ==(other)
+      content_id == other.content_id
+    end
+
+    def hash
+      content_id.hash
+    end
+
+    def eql?(other)
+      self == other
     end
   end
 end

--- a/lib/govuk_navigation_helpers/curated_taxonomy_sidebar_links.rb
+++ b/lib/govuk_navigation_helpers/curated_taxonomy_sidebar_links.rb
@@ -1,0 +1,96 @@
+require 'set'
+
+module GovukNavigationHelpers
+  class CuratedTaxonomySidebarLinks
+    def initialize(content_item)
+      @content_item = content_item
+    end
+
+    def related_items
+      @related_items ||=
+        taxon_links +
+        elsewhere_on_gov_uk_links +
+        elsewhere_on_the_web_links
+    end
+
+  private
+
+    def taxon_links
+      @content_item.parent_taxons.map do |taxon|
+        {
+          title: taxon.title,
+          url: taxon.base_path,
+          description: taxon.description,
+          related_content: format_for_sidebar(related_content_by_taxon[taxon]),
+        }
+      end
+    end
+
+    def elsewhere_on_gov_uk_links
+      elsewhere_items = related_content_elsewhere_on_govuk
+      return [] if elsewhere_items.empty?
+
+      [
+        {
+          title: 'Elsewhere on GOV.UK',
+          related_content: format_for_sidebar(elsewhere_items),
+        },
+      ]
+    end
+
+    def elsewhere_on_the_web_links
+      return [] if @content_item.external_links.empty?
+
+      external_links = @content_item.external_links.map do |link|
+        {
+          title: link['title'],
+          link: link['url'],
+        }
+      end
+
+      [
+        {
+          title: 'Elsewhere on the web',
+          related_content: external_links,
+        },
+      ]
+    end
+
+    def related_content_by_taxon
+      @related_items_by_taxon ||= begin
+        curated_related_items = @content_item.curated_taxonomy_sidebar_links.to_set
+
+        @content_item.parent_taxons.each_with_object({}) do |taxon, items_by_taxon|
+          items_related_to_taxon = filter_items_by_taxon(curated_related_items, taxon)
+          items_by_taxon[taxon] = items_related_to_taxon
+          curated_related_items = undisplayed_items(curated_related_items, items_related_to_taxon)
+        end
+      end
+    end
+
+    def related_content_elsewhere_on_govuk
+      @related_content_elsewhere_on_govuk ||= begin
+        related_content = @content_item.curated_taxonomy_sidebar_links.to_set
+        related_taxon_content = related_content_by_taxon.values.flatten.to_set
+        related_content - related_taxon_content
+      end
+    end
+
+    def filter_items_by_taxon(items, taxon)
+      items.select do |item|
+        item.parent_taxons.include?(taxon)
+      end
+    end
+
+    def undisplayed_items(all_items, displayed_items)
+      all_items - displayed_items
+    end
+
+    def format_for_sidebar(collection)
+      collection
+        .to_a
+        .sort_by(&:title)
+        .map(&:as_taxonomy_sidebar_link)
+    end
+  end
+end

--- a/lib/govuk_navigation_helpers/rummager_taxonomy_sidebar_links.rb
+++ b/lib/govuk_navigation_helpers/rummager_taxonomy_sidebar_links.rb
@@ -1,0 +1,61 @@
+module GovukNavigationHelpers
+  class RummagerTaxonomySidebarLinks
+    def initialize(content_item)
+      @content_item = content_item
+    end
+
+    def related_items
+      parent_taxons = @content_item.parent_taxons
+      used_related_links = Set.new
+
+      parent_taxons.each_with_index.map do |parent_taxon, index|
+        related_content = index < 2 ? content_related_to(parent_taxon, used_related_links) : []
+
+        used_related_links.merge(
+          related_content.map { |content| content[:link] }
+        )
+
+        {
+          title: parent_taxon.title,
+          url: parent_taxon.base_path,
+          description: parent_taxon.description,
+          related_content: related_content,
+        }
+      end
+    end
+
+  private
+
+    # This method will fetch content related to content_item, and tagged to taxon. This is a
+    # temporary method that uses search to achieve this. This behaviour is to be moved into
+    # the content store
+    def content_related_to(taxon, used_related_links)
+      statsd.time(:taxonomy_sidebar_search_time) do
+        begin
+          results = Services.rummager.search(
+            similar_to: @content_item.base_path,
+            start: 0,
+            count: 3,
+            filter_taxons: [taxon.content_id],
+            filter_navigation_document_supertype: 'guidance',
+            reject_link: used_related_links.to_a,
+            fields: %w[title link],
+          )['results']
+
+          statsd.increment(:taxonomy_sidebar_searches)
+
+          results
+            .map { |result| { title: result['title'], link: result['link'], } }
+            .sort_by { |result| result[:title] }
+        rescue StandardError => e
+          GovukNavigationHelpers.configuration.error_handler.notify(e)
+          []
+        end
+      end
+    end
+
+    def statsd
+      GovukNavigationHelpers.configuration.statsd
+    end
+  end
+end

--- a/spec/taxonomy_sidebar_spec.rb
+++ b/spec/taxonomy_sidebar_spec.rb
@@ -186,6 +186,273 @@ RSpec.describe GovukNavigationHelpers::TaxonomySidebar do
       end
     end
 
+    context 'when there are related link overrides' do
+      context 'belonging to the same taxon' do
+        it 'displays the related link overrides under a single taxon' do
+          content_item = content_item_tagged_to_taxon
+
+          content_item['links']['ordered_related_items_overrides'] = [
+            {
+              'title' => 'Related link override B',
+              'base_path' => '/override-b',
+              'content_id' => 'override-b',
+              'links' => {
+                'taxons' => [
+                  content_item['links']['taxons'][0],
+                ],
+              },
+            },
+          ]
+
+          expect(sidebar_for(content_item)).to eq(
+            items: [
+              {
+                title: "Taxon A",
+                url: "/taxon-a",
+                description: "The A taxon.",
+                related_content: [],
+              },
+              {
+                title: "Taxon B",
+                url: "/taxon-b",
+                description: "The B taxon.",
+                related_content: [
+                  { title: 'Related link override B', link: '/override-b' },
+                ],
+              }
+            ]
+          )
+        end
+
+        it 'displays the related link overrides under a multiple taxons' do
+          content_item = content_item_tagged_to_taxon
+
+          content_item['links']['ordered_related_items_overrides'] = [
+            {
+              'title' => 'Related link override B',
+              'base_path' => '/override-b',
+              'content_id' => 'override-b',
+              'links' => {
+                'taxons' => [
+                  content_item['links']['taxons'][0],
+                ],
+              },
+            },
+            {
+              'title' => 'Related link override A-2',
+              'base_path' => '/override-a-2',
+              'content_id' => 'override-a-2',
+              'links' => {
+                'taxons' => [
+                  content_item['links']['taxons'][1],
+                ],
+              },
+            },
+            {
+              'title' => 'Related link override A-1',
+              'base_path' => '/override-a-1',
+              'content_id' => 'override-a-1',
+              'links' => {
+                'taxons' => [
+                  content_item['links']['taxons'][1],
+                ],
+              },
+            },
+          ]
+
+          expect(sidebar_for(content_item)).to eq(
+            items: [
+              {
+                title: "Taxon A",
+                url: "/taxon-a",
+                description: "The A taxon.",
+                related_content: [
+                  { 'title': 'Related link override A-1', 'link': '/override-a-1' },
+                  { 'title': 'Related link override A-2', 'link': '/override-a-2' },
+                ],
+              },
+              {
+                title: "Taxon B",
+                url: "/taxon-b",
+                description: "The B taxon.",
+                related_content: [
+                  { 'title': 'Related link override B', 'link': '/override-b' },
+                ],
+              }
+            ]
+          )
+        end
+
+        it 'displays a related link tagged to multiple taxons under a single taxon' do
+          content_item = content_item_tagged_to_taxon
+
+          content_item['links']['ordered_related_items_overrides'] = [
+            {
+              'title' => 'Related link override',
+              'base_path' => '/override',
+              'content_id' => 'override',
+              'links' => {
+                'taxons' => [
+                  content_item['links']['taxons'][0],
+                  content_item['links']['taxons'][1],
+                ],
+              },
+            },
+          ]
+
+          expect(sidebar_for(content_item)).to eq(
+            items: [
+              {
+                title: "Taxon A",
+                url: "/taxon-a",
+                description: "The A taxon.",
+                related_content: [
+                  { 'title': 'Related link override', 'link': '/override' },
+                ],
+              },
+              {
+                title: "Taxon B",
+                url: "/taxon-b",
+                description: "The B taxon.",
+                related_content: [],
+              }
+            ]
+          )
+        end
+
+        it 'displays a related link tagged to another taxon under "Elsewhere"' do
+          content_item = content_item_tagged_to_taxon
+
+          content_item['links']['ordered_related_items_overrides'] = [
+            {
+              'title' => 'Related link override',
+              'base_path' => '/override',
+              'content_id' => 'override',
+              'links' => {
+                'taxons' => [
+                  {
+                    'title' => 'Some other taxon',
+                    'content_id' => 'some-other-taxon',
+                    'base_path' => '/some-other-taxon',
+                  }
+                ],
+              },
+            },
+          ]
+
+          expect(sidebar_for(content_item)).to eq(
+            items: [
+              {
+                title: "Taxon A",
+                url: "/taxon-a",
+                description: "The A taxon.",
+                related_content: [],
+              },
+              {
+                title: "Taxon B",
+                url: "/taxon-b",
+                description: "The B taxon.",
+                related_content: [],
+              },
+              {
+                title: "Elsewhere on GOV.UK",
+                related_content: [
+                  { title: 'Related link override', link: '/override' }
+                ],
+              },
+            ]
+          )
+        end
+
+        it 'displays a related link not tagged to any taxons under "Elsewhere"' do
+          content_item = content_item_tagged_to_taxon
+
+          content_item['links']['ordered_related_items_overrides'] = [
+            {
+              'title' => 'Related link override',
+              'base_path' => '/override',
+              'content_id' => 'override',
+              'links' => {},
+            },
+          ]
+
+          expect(sidebar_for(content_item)).to eq(
+            items: [
+              {
+                title: "Taxon A",
+                url: "/taxon-a",
+                description: "The A taxon.",
+                related_content: [],
+              },
+              {
+                title: "Taxon B",
+                url: "/taxon-b",
+                description: "The B taxon.",
+                related_content: [],
+              },
+              {
+                title: "Elsewhere on GOV.UK",
+                related_content: [
+                  { title: 'Related link override', link: '/override' }
+                ],
+              },
+            ]
+          )
+        end
+
+        it 'displays an external related link under "Elsewhere"' do
+          content_item = content_item_tagged_to_taxon
+
+          content_item['links']['ordered_related_items_overrides'] = [
+            {
+              'title' => 'Related link override',
+              'base_path' => '/override',
+              'content_id' => 'override',
+              'links' => {},
+            },
+          ]
+
+          content_item['details'] = {
+            'external_related_links' => [
+              {
+                'title' => 'External related link',
+                'url' => 'http://example.com',
+              },
+            ]
+          }
+
+          expect(sidebar_for(content_item)).to eq(
+            items: [
+              {
+                title: "Taxon A",
+                url: "/taxon-a",
+                description: "The A taxon.",
+                related_content: [],
+              },
+              {
+                title: "Taxon B",
+                url: "/taxon-b",
+                description: "The B taxon.",
+                related_content: [],
+              },
+              {
+                title: "Elsewhere on GOV.UK",
+                related_content: [
+                  { title: 'Related link override', link: '/override' }
+                ],
+              },
+              {
+                title: "Elsewhere on the web",
+                related_content: [
+                  { title: 'External related link', link: 'http://example.com' }
+                ],
+              },
+            ]
+          )
+        end
+      end
+    end
+
     context 'when Rummager raises an exception' do
       error_handler = nil
 


### PR DESCRIPTION
When a content item has related link overrides for the new education
(configured in `content-tagger`), then `govuk_navigation_helpers` will
present a hash that contains these curated links, rather than the
Elasticsearch “More like this” links generated by `rummager`.

Curated links are grouped according to the following rules:

- If a related item has a taxon in common with the content, then display
  the related item under that taxon in the sidebar (avoiding duplicates)
- Otherwise display a related item under the “Elsewhere on GOV.UK”
  section
- Any external related links are displayed under “Elsewhere on the web”.
  External related links currently use the same external links as the
  “old” related items sidebar. In order to prevent sidebar overrides
  for content items with external related links, but no “new” GOV.UK
  related links, we only display curated links if there are GOV.UK
  related links present. This means it is currently impossible to
  display only external related links in the new navigation.

## Before

![curated-sidebar-before](https://cloud.githubusercontent.com/assets/12036746/26688074/94e037ee-46e9-11e7-87da-6875dd7c8fd2.png)

## After

![curated-sidebar-after](https://cloud.githubusercontent.com/assets/12036746/26688071/93d16a9e-46e9-11e7-8719-4002b970841c.png)

## Dependencies

- [x] https://github.com/alphagov/static/pull/1065

## Trello

https://trello.com/c/J8ofEnrt/167-display-curated-related-links-in-the-sidebar