### PR TITLE
Whitelist root taxons

### DIFF
--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -5,6 +5,18 @@ module GovukNavigationHelpers
   #
   # @private
   class ContentItem
+    WORLD_TAXON_CONTENT_ID = "91b8ef20-74e7-4552-880c-50e6d73c2ff9".freeze
+    EDUCATION_TAXON_CONTENT_ID = "c58fdadd-7743-46d6-9629-90bb3ccc4ef0".freeze
+    CHILDCARE_PARENTING_TAXON_CONTENT_ID = "206b7f3a-49b5-476f-af0f-fd27e2a68473".freeze
+
+    def self.whitelisted_root_taxon_content_ids
+      [
+        WORLD_TAXON_CONTENT_ID,
+        EDUCATION_TAXON_CONTENT_ID,
+        CHILDCARE_PARENTING_TAXON_CONTENT_ID,
+      ]
+    end
+
     attr_reader :content_store_response
 
     def initialize(content_store_response)
@@ -24,14 +36,11 @@ module GovukNavigationHelpers
     end
 
     def parent_taxons
-      # First handle the case for content items tagged to the taxonomy.
-      taxons = Array(content_store_response.dig("links", "taxons"))
-      return taxons.map { |taxon| ContentItem.new(taxon) }.sort_by(&:title) if taxons.any?
-
-      # If that link isn't present, assume we're dealing with a taxon and check
-      # for its parents in the taxonomy.
-      parent_taxons = Array(content_store_response.dig("links", "parent_taxons"))
-      parent_taxons.map { |taxon| ContentItem.new(taxon) }.sort_by(&:title)
+      @_parent_taxons ||= begin
+        taxon_links
+          .select { |t| descendent_from_whitelisted_root_taxon?(t) }
+          .map { |taxon| ContentItem.new(taxon) }.sort_by(&:title)
+      end
     end
 
     def mainstream_browse_pages
@@ -89,6 +98,30 @@ module GovukNavigationHelpers
 
     def eql?(other)
       self == other
+    end
+
+  private
+
+    def taxon_links
+      # A normal content item's taxon links are stored in ["links"]["taxons"]
+      # whereas a Taxon content item's taxon links are stored in ["links"]["parent_taxons"]
+      # so here we cater for both possibilities
+      content_store_response.dig("links", "taxons") || content_store_response.dig("links", "parent_taxons") || []
+    end
+
+    def descendent_from_whitelisted_root_taxon?(taxon)
+      root_taxon = get_root_taxon(taxon)
+      ContentItem.whitelisted_root_taxon_content_ids.include?(root_taxon["content_id"])
+    end
+
+    def get_root_taxon(taxon)
+      parent_taxons = taxon.dig("links", "parent_taxons")
+
+      if parent_taxons.nil? || parent_taxons.empty?
+        taxon
+      else
+        get_root_taxon(parent_taxons.first)
+      end
     end
   end
 end

--- a/spec/content_item_spec.rb
+++ b/spec/content_item_spec.rb
@@ -1,0 +1,212 @@
+require "spec_helper"
+
+RSpec.describe GovukNavigationHelpers::ContentItem do
+  describe ".whitelisted_root_taxon_content_ids" do
+    it "returns the whitelisted content_ids" do
+      expected_content_ids = [
+        "91b8ef20-74e7-4552-880c-50e6d73c2ff9",
+        "c58fdadd-7743-46d6-9629-90bb3ccc4ef0",
+        "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+      ]
+
+      content_ids = described_class.whitelisted_root_taxon_content_ids
+      expect(content_ids).to eq(expected_content_ids)
+    end
+  end
+
+  describe "#parent_taxons" do
+    before do
+      allow(described_class)
+        .to receive(:whitelisted_root_taxon_content_ids)
+        .and_return(["aaaa-bbbb"])
+    end
+
+    context "for a content item with taxons links" do
+      context "with a whitelisted parent taxon" do
+        let(:taxon) do
+          {
+            "content_id" => "cccc-dddd",
+            "title" => "Taxon",
+            "links" => {
+              "parent_taxons" => [
+                {
+                  "content_id" => "aaaa-bbbb",
+                  "title" => "Taxon",
+                }
+              ]
+            }
+          }
+        end
+
+        let(:content_item_response) do
+          {
+            "title" => "Some Answer Content Item",
+            "document_type" => "answer",
+            "links" => {
+              "taxons" => [taxon],
+            }
+          }
+        end
+
+        it "returns the parent taxons" do
+          expected_parent_taxon = described_class.new(taxon)
+          expect(described_class.new(content_item_response).parent_taxons).to contain_exactly(expected_parent_taxon)
+        end
+      end
+
+      context "with a non-whitelisted parent taxon" do
+        let(:taxon) do
+          {
+            "content_id" => "cccc-dddd",
+            "title" => "Taxon",
+            "links" => {
+              "parent_taxons" => [
+                {
+                  "content_id" => "xxxx-xxxx",
+                  "title" => "Non Whitelisted Taxon",
+                }
+              ]
+            }
+          }
+        end
+
+        let(:content_item_response) do
+          {
+            "title" => "Some Answer Content Item",
+            "document_type" => "answer",
+            "links" => {
+              "taxons" => [taxon],
+            }
+          }
+        end
+
+        it "returns an empty array" do
+          expect(described_class.new(content_item_response).parent_taxons).to eq([])
+        end
+      end
+    end
+
+    context "for a content item with no taxons links" do
+      context "with missing links hash" do
+        let(:content_item_response) do
+          {
+            "title" => "Some Answer Content Item",
+            "document_type" => "answer",
+          }
+        end
+
+        it "returns an empty array" do
+          expect(described_class.new(content_item_response).parent_taxons).to eq([])
+        end
+      end
+
+      context "with missing taxons links hash" do
+        let(:content_item_response) do
+          {
+            "title" => "Some Answer Content Item",
+            "document_type" => "answer",
+            "links" => {},
+          }
+        end
+
+        it "returns an empty array" do
+          expect(described_class.new(content_item_response).parent_taxons).to eq([])
+        end
+      end
+    end
+
+    context "for a taxon content item with parent taxon links" do
+      context "with a whitelisted parent taxon" do
+        let(:taxon) do
+          {
+            "content_id" => "cccc-dddd",
+            "title" => "Taxon",
+            "links" => {
+              "parent_taxons" => [
+                {
+                  "content_id" => "aaaa-bbbb",
+                  "title" => "Taxon",
+                }
+              ]
+            }
+          }
+        end
+
+        let(:content_item_response) do
+          {
+            "title" => "Some Taxon Content Item",
+            "document_type" => "taxon",
+            "links" => {
+              "parent_taxons" => [taxon],
+            }
+          }
+        end
+
+        it "returns the parent taxons" do
+          expected_parent_taxon = described_class.new(taxon)
+          expect(described_class.new(content_item_response).parent_taxons).to contain_exactly(expected_parent_taxon)
+        end
+      end
+
+      context "with a non-whitelisted parent taxon" do
+        let(:taxon) do
+          {
+            "content_id" => "cccc-dddd",
+            "title" => "Taxon",
+            "links" => {
+              "parent_taxons" => [
+                {
+                  "content_id" => "xxxx-xxxx",
+                  "title" => "Non Whitelisted Taxon",
+                }
+              ]
+            }
+          }
+        end
+
+        let(:content_item_response) do
+          {
+            "title" => "Some Taxon Content Item",
+            "document_type" => "taxon",
+            "links" => {
+              "parent_taxons" => [taxon],
+            }
+          }
+        end
+
+        it "returns an empty array" do
+          expect(described_class.new(content_item_response).parent_taxons).to eq([])
+        end
+      end
+    end
+
+    context "for a taxon content item with no parent taxons links" do
+      context "with missing links hash" do
+        let(:content_item_response) do
+          {
+            "title" => "Some Taxon Content Item",
+            "document_type" => "taxon",
+          }
+        end
+
+        it "returns an empty array" do
+          expect(described_class.new(content_item_response).parent_taxons).to eq([])
+        end
+      end
+
+      context "with missing parent taxons links hash" do
+        let(:content_item_response) do
+          {
+            "title" => "Some Taxon Content Item",
+            "document_type" => "taxon",
+            "links" => {},
+          }
+        end
+
+        it "returns an empty array" do
+          expect(described_class.new(content_item_response).parent_taxons).to eq([])
+        end
+      end
+    end
+  end
+end

--- a/spec/taxon_breadcrumbs_spec.rb
+++ b/spec/taxon_breadcrumbs_spec.rb
@@ -2,6 +2,12 @@ require 'spec_helper'
 
 RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
   describe "Taxon breadcrumbs" do
+    before do
+      allow(GovukNavigationHelpers::ContentItem)
+        .to receive(:whitelisted_root_taxon_content_ids)
+        .and_return(['30c1b93d-2553-47c9-bc3c-fc5b513ecc32'])
+    end
+
     it "can handle any valid content item" do
       generator = GovukSchemas::RandomExample.for_schema(
         "taxon",

--- a/spec/taxonomy_sidebar_spec.rb
+++ b/spec/taxonomy_sidebar_spec.rb
@@ -6,6 +6,12 @@ include GdsApi::TestHelpers::Rummager
 
 RSpec.describe GovukNavigationHelpers::TaxonomySidebar do
   describe '#sidebar' do
+    before do
+      allow(GovukNavigationHelpers::ContentItem)
+        .to receive(:whitelisted_root_taxon_content_ids)
+        .and_return(['taxon-a', 'taxon-b', 'taxon-c'])
+    end
+
     it 'can handle any valid content item' do
       stub_any_rummager_search_to_return_no_results
 


### PR DESCRIPTION
For https://trello.com/c/b3TTdin2/157-prevent-publishers-seeing-draft-taxons-in-government-frontend

Since we’ve created the new single taxonomy in draft in Production, some publishers have been seeing some of those draft taxons in the sidebar and breadcrumbs when previewing their content on the draft stack.

In order to avoid this, we add a hardcoded whitelist of taxons which we want to show (including all their sub taxons), both in draft and production. This whitelist corresponds to the current published branches World, Education and Parenting. We currently don’t expect to be publishing any new taxonomy branches, so we think that this approach will work for the time being. We expect to remove this whitelist when the single taxonomy is more settled and/or is published.