### PR TITLE
Update to version 7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 7.0.0
+
+* Root taxons are now whitelisted, so that only taxons descendant from one of
+  the three published root taxons (education, childcare-parenting and world)
+  will appear in breadcrumbs and the side bar. See the [PR](https://github.com/alphagov/govuk_navigation_helpers/pull/82) for more information
+
 ## 6.3.0
 
 * Allow curated related links to be shown on the new navigation sidebar. If the

--- a/lib/govuk_navigation_helpers/version.rb
+++ b/lib/govuk_navigation_helpers/version.rb
@@ -1,3 +1,3 @@
 module GovukNavigationHelpers
-  VERSION = "6.3.0".freeze
+  VERSION = "7.0.0".freeze
 end


### PR DESCRIPTION
Root taxons are now whitelisted, so that only taxons descendant from one of
the three published root taxons (education, childcare-parenting and world)
will appear in breadcrumbs and the side bar. See the [PR](https://github.com/alphagov/govuk_navigation_helpers/pull/82) for more information