### PR TITLE
Update version 7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.1.0
+
+* Add helper for rendering related navigation sidebar on content pages with universal layout
+
 ## 7.0.0
 
 * Root taxons are now whitelisted, so that only taxons descendant from one of

--- a/lib/govuk_navigation_helpers/version.rb
+++ b/lib/govuk_navigation_helpers/version.rb
@@ -1,3 +1,3 @@
 module GovukNavigationHelpers
-  VERSION = "7.0.0".freeze
+  VERSION = "7.1.0".freeze
 end


### PR DESCRIPTION
Add helper which provides data for related navigation sidebar which will be used on content pages with unvirsal layout. Logic is in addition to existing related items and taxonomy sidebar, so not a breaking change.