### PR TITLE
Return world location data for related navigation

### DIFF
--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -105,6 +105,10 @@ module GovukNavigationHelpers
       filter_link_type(content_store_response.dig("links", "topics").to_a, "topic")
     end
 
+    def related_world_locations
+      content_store_response.dig("links", "world_locations").to_a
+    end
+
     def external_links
       content_store_response.dig("details", "external_related_links").to_a
     end

--- a/lib/govuk_navigation_helpers/related_navigation_sidebar.rb
+++ b/lib/govuk_navigation_helpers/related_navigation_sidebar.rb
@@ -14,6 +14,7 @@ module GovukNavigationHelpers
         topics: related_topics,
         policies: related_policies,
         publishers: related_organisations,
+        world_locations: related_world_locations,
         other: [related_external_links, related_contacts]
       }
     end
@@ -29,6 +30,10 @@ module GovukNavigationHelpers
       end
     end
 
+    def world_location_base_path(title)
+      "/world/#{title.downcase.tr(' ', '-')}/news"
+    end
+
     def related_items
       quick_links = build_links_for_sidebar(@content_item.quick_links, "url")
 
@@ -37,6 +42,12 @@ module GovukNavigationHelpers
 
     def related_organisations
       build_links_for_sidebar(@content_item.related_organisations)
+    end
+
+    def related_world_locations
+      locations = @content_item.related_world_locations
+      locations.map! { |link| link.merge("base_path" => world_location_base_path(link["title"])) }
+      build_links_for_sidebar(locations)
     end
 
     def related_collections

--- a/spec/navigation_sidebar_spec.rb
+++ b/spec/navigation_sidebar_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe GovukNavigationHelpers::RelatedNavigationSidebar do
         topics: [],
         policies: [],
         publishers: [],
+        world_locations: [],
         other: [[], []]
       }
 
@@ -91,7 +92,14 @@ RSpec.describe GovukNavigationHelpers::RelatedNavigationSidebar do
               "title" => "related policy",
               "document_type" => "policy"
             }
-          ]
+          ],
+          "world_locations" => [
+            {
+              "content_id" => "32c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+              "title" => "World Location",
+              "locale" => "en"
+            }
+          ],
         }
       )
 
@@ -101,6 +109,7 @@ RSpec.describe GovukNavigationHelpers::RelatedNavigationSidebar do
         topics: [{ path: "/related-topic", text: "related topic" }],
         policies: [{ path: "/related-policy", text: "related policy" }],
         publishers: [{ path: "/related-organisation", text: "related organisation" }],
+        world_locations: [{ path: "/world/world-location/news", text: "World Location" }],
         other: [[], []]
       }
 


### PR DESCRIPTION
We want to show world location data alongside organisations in the related navigation component. 

This will live in its own section in the related navigation component, e.g:
<img width="1000" alt="screen shot 2017-12-06 at 13 14 04" src="https://user-images.githubusercontent.com/29889908/33663322-5e1aa564-da87-11e7-98c7-352bb208b1af.png">

The title for this section is still WIP, but this change will be made in `government-frontend` as part of https://github.com/alphagov/government-frontend/pull/565

