### PR TITLE
Add TasklistContent & CurrentTasklistAbTest

### DIFF
--- a/config/tasklists/end-a-civil-partnership.json
+++ b/config/tasklists/end-a-civil-partnership.json
@@ -1,0 +1,339 @@
+{
+  "title": "End a civil partnership: step by step",
+  "base_path": "/end-a-civil-partnership",
+  "description": "<p>Find out how to legally end your civil partnership in England and Wales.</p><p>There is a different process if you're in <a href=\"https://www.scotcourts.gov.uk/taking-action/divorce-and-dissolution-of-civil-partnership\">Scotland</a> or <a href=\"https://www.nidirect.gov.uk/articles/getting-divorcedissolution-civil-partnership\">Northern Ireland</a>.</p>",
+  "links": {
+    "breadcrumbs": [
+      {
+        "title": "Home",
+        "url": "/"
+      },
+      {
+        "title": "Births, deaths, marriages and care",
+        "url": "/browse/births-deaths-marriages"
+      },
+      {
+        "title": "Marriage, civil partnership and divorce",
+        "url": "/browse/births-deaths-marriages/marriage-divorce"
+      }
+    ]
+  },
+  "ab_test_prefix": "CivilPartnership",
+  "related_paths": [
+    "/looking-after-children-divorce/if-you-agree",
+    "/looking-after-children-divorce/mediation",
+    "/looking-after-children-divorce/types-of-court-order",
+    "/looking-after-children-divorce/apply-for-court-order",
+    "/looking-after-children-divorce/after-you-apply-for-a-court-order",
+    "/looking-after-children-divorce/change-or-enforce-an-order",
+    "/money-property-when-relationship-ends/apply-for-consent-order",
+    "/money-property-when-relationship-ends/mediation",
+    "/money-property-when-relationship-ends/apply-for-a-financial-order",
+    "/money-property-when-relationship-ends/how-the-court-splits-assets",
+    "/money-property-when-relationship-ends/maintenance-payments",
+    "/money-property-when-relationship-ends/tax",
+    "/visas-when-you-separate-or-divorce/apply-stay-uk",
+    "/stay-in-home-during-separation-or-divorce/apply-if-the-property-is-registered",
+    "/stay-in-home-during-separation-or-divorce/apply-if-the-property-is-unregistered"
+  ],
+  "tasklist": {
+    "groups": [
+      [
+        {
+          "title": "Get support and advice",
+          "optional": true,
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "You can get support and advice to help you deal with disputes and emotional stress."
+            },
+            {
+              "type": "list",
+              "contents": [
+                {
+                  "href": "https://www.relate.org.uk/relationship-help/help-separation-and-divorce",
+                  "text": "Get advice from Relate"
+                },
+                {
+                  "href": "https://www.relate.org.uk/relationship-help/talk-someone",
+                  "text": "Get counselling from Relate (in person, by phone or online)"
+                },
+                {
+                  "href": "http://www.counselling-directory.org.uk/adv-search.html",
+                  "text": "Find a counsellor",
+                  "context": "£35 to £60 per session"
+                },
+                {
+                  "href": "https://www.samaritans.org/how-we-can-help-you/contact-us",
+                  "text": "Contact the Samaritans if you need to speak to someone urgently"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Check you can end a civil partnership",
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "You must meet certain legal requirements for you to end your civil partnership."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/end-civil-partnership",
+                  "text": "Check your civil partnership meets the criteria"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Make arrangements for your children, money and property",
+          "optional": true,
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "You should try to agree how you'll deal with your children, money and property before you apply to end your civil partnership."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/looking-after-children-divorce",
+                  "text": "Make arrangements for your children"
+                },
+                {
+                  "href": "/money-property-when-relationship-ends",
+                  "text": "Divide your money and property"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "text": "You should also check if ending your civil partnership will affect:"
+            },
+            {
+              "type": "list",
+              "style": "choice",
+              "contents": [
+                {
+                  "href": "/benefits-calculators",
+                  "text": "benefits you're eligible for"
+                },
+                {
+                  "href": "/report-benefits-change-circumstances",
+                  "text": "benefits you already receive"
+                },
+                {
+                  "href": "/contact-pension-service",
+                  "text": "your State Pension"
+                },
+                {
+                  "href": "/visas-when-you-separate-or-divorce",
+                  "text": "your UK visa status"
+                },
+                {
+                  "href": "/stay-in-home-during-separation-or-divorce",
+                  "text": "whether you can live in your current home"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "File an application",
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "You need to fill in a dissolution application."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/end-civil-partnership/file-application",
+                  "text": "How to start the process to end your civil partnership"
+                },
+                {
+                  "href": "/end-civil-partnership/grounds-for-ending-a-civil-partnership",
+                  "text": "Check the list of reasons why you can end a civil partnership"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=1115",
+                  "text": "Fill in a dissolution application form"
+                },
+                {
+                  "href": "/end-civil-partnership/file-application",
+                  "text": "Pay the court fee",
+                  "context": "£550"
+                },
+                {
+                  "href": "/get-help-with-court-fees",
+                  "text": "Get help with court fees"
+                },
+                {
+                  "href": "https://courttribunalfinder.service.gov.uk/search/",
+                  "text": "Send copies of the form to your nearest divorce centre"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "text": "Your civil partner will receive a copy of the dissolution application. You'll be told when they respond and what you'll need to do next."
+            },
+            {
+              "type": "paragraph",
+              "text": "You might need to get legal advice if your civil partner disagrees with your application."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/find-a-legal-adviser",
+                  "text": "Get legal advice"
+                }
+              ]
+            },
+            {
+              "type": "substep",
+              "optional": true
+            },
+            {
+              "type": "list",
+              "contents": [
+                {
+                  "href": "/divorce-missing-husband-wife",
+                  "text": "Find your civil partner's address",
+                  "context": "£0 to £100"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=1112",
+                  "text": "Apply to skip the dissolution order if you can’t find their address",
+                  "context": "£50"
+                },
+                {
+                  "href": "/divorce/if-your-husband-or-wife-lacks-mental-capacity",
+                  "text": "Get help if your civil partner can’t make decisions for themselves"
+                },
+                {
+                  "href": "/divorce-missing-husband-wife",
+                  "text": "End the civil partnership because you think your partner is dead",
+                  "context": "£365"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Send the court more details about ending your civil partnership",
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "If the court agrees with your dissolution application, you can apply for a document called a 'conditional order'. You can give more information about why the civil partnership has broken down."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/end-civil-partnership/apply-for-a-conditional-order",
+                  "text": "Why you need a conditional order"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=154",
+                  "text": "Fill in the application form"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "text": "You need to say why you're ending the civil partnership. Choose the form that matches what you put in the dissolution application:"
+            },
+            {
+              "type": "list",
+              "style": "choice",
+              "contents": [
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=144",
+                  "text": "unreasonable behaviour"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=142",
+                  "text": "adultery"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=146",
+                  "text": "desertion"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=149",
+                  "text": "2 years' separation"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=150",
+                  "text": "5 years' separation"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "text": "Send the forms to the court. "
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Finalise your divorce",
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "Once you, your civil partner and the court all agree, you can apply for a document called a 'final order' to end your civil partnership. You can do this 6 weeks to 12 months after you receive the conditional order."
+            },
+            {
+              "type": "paragraph",
+              "text": "If you want a legally-binding arrangement for dividing money and property you must apply to the court for this before you apply for a final order."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/end-civil-partnership/apply-for-a-final-order",
+                  "text": "Why you need a final order"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=1114",
+                  "text": "Fill in the final order application form"
+                }
+
+              ]
+            },
+            {
+              "type": "paragraph",
+              "text": "Send the forms to the court."
+            },
+            {
+              "type": "paragraph",
+              "text": "Once it's approved, they'll send you both a copy of the final order to say your civil partnership has legally ended."
+            }
+          ]
+        }
+      ]
+    ]
+  }
+}

--- a/config/tasklists/get-a-divorce.json
+++ b/config/tasklists/get-a-divorce.json
@@ -1,0 +1,337 @@
+{
+  "title": "Get a divorce: step by step",
+  "base_path": "/get-a-divorce",
+  "description": "<p>How to file for divorce if you’re in England or Wales.</p><p>There is a different process if you’re <a href=\"/divorce/respond-to-a-divorce-petition\">responding to a divorce petition</a>, or if you’re in <a href=\"https://www.scotcourts.gov.uk/taking-action/divorce-and-dissolution-of-civil-partnership\">Scotland</a> or <a href=\"https://www.nidirect.gov.uk/articles/getting-divorcedissolution-civil-partnership\">Northern Ireland</a>.</p>",
+  "links": {
+    "breadcrumbs": [
+      {
+        "title": "Home",
+        "url": "/"
+      },
+      {
+        "title": "Births, deaths, marriages and care",
+        "url": "/browse/births-deaths-marriages"
+      },
+      {
+        "title": "Marriage, civil partnership and divorce",
+        "url": "/browse/births-deaths-marriages/marriage-divorce"
+      }
+    ]
+  },
+  "ab_test_prefix": "GetADivorce",
+  "related_paths": [
+    "/stay-in-home-during-separation-or-divorce",
+    "/copy-decree-absolute-final-order",
+    "/visas-when-you-separate-or-divorce",
+    "/contact-grandchild-parents-divorce-separate",
+    "/government/publications/application-for-a-state-pension-forecast-on-divorce-or-dissolution-br20",
+    "/government/publications/family-law-the-ground-for-divorce",
+    "/government/publications/get-a-copy-of-a-domestic-violence-protection-notice--2",
+    "/how-to-annul-marriage",
+    "/marriage-allowance/if-your-circumstances-change",
+    "/changing-passport-information/divorce-or-returning-to-a-previous-surname",
+    "/make-will/updating-your-will",
+    "/marriage-allowance/if-your-circumstances-change",
+    "/marriage-allowance/how-to-apply",
+    "/make-will",
+    "/make-will/writing-your-will",
+    "/make-will/make-sure-your-will-is-legal",
+    "/divorce/respond-to-a-divorce-petition"
+  ],
+  "tasklist": {
+    "groups": [
+      [
+        {
+          "title": "Get support and advice",
+          "optional": true,
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "You can get support and advice to help you deal with disputes and emotional stress."
+            },
+            {
+              "type": "list",
+              "contents": [
+                {
+                  "href": "https://www.relate.org.uk/relationship-help/help-separation-and-divorce",
+                  "text": "Get advice from Relate"
+                },
+                {
+                  "href": "https://www.relate.org.uk/relationship-help/talk-someone",
+                  "text": "Get counselling from Relate (in person, by phone or online)"
+                },
+                {
+                  "href": "http://www.counselling-directory.org.uk/adv-search.html",
+                  "text": "Find a counsellor",
+                  "context": "£35 to £60 per session"
+                },
+                {
+                  "href": "https://www.samaritans.org/how-we-can-help-you/contact-us",
+                  "text": "Contact the Samaritans if you need to speak to someone urgently"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Check you can get a divorce",
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "Your marriage must meet certain legal requirements for you to be able to get a divorce."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/divorce",
+                  "text": "Check you can get a divorce"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Make arrangements for your children, money and property",
+          "optional": true,
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "You should try to agree how you'll deal with your children, money and property before you start your divorce."
+            },
+            {
+              "type": "list",
+              "contents": [
+                {
+                  "href": "/looking-after-children-divorce",
+                  "text": "Make arrangements for your children"
+                },
+                {
+                  "href": "/money-property-when-relationship-ends",
+                  "text": "Divide your money and property"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "text": "You should also check if your divorce will affect:"
+            },
+            {
+              "type": "list",
+              "style": "choice",
+              "contents": [
+                {
+                  "href": "/benefits-calculators",
+                  "text": "benefits you're eligible for"
+                },
+                {
+                  "href": "/report-benefits-change-circumstances",
+                  "text": "benefits you already receive"
+                },
+                {
+                  "href": "/contact-pension-service",
+                  "text": "your State Pension"
+                },
+                {
+                  "href": "/visas-when-you-separate-or-divorce",
+                  "text": "your UK visa status"
+                },
+                {
+                  "href": "/stay-in-home-during-separation-or-divorce",
+                  "text": "whether you can live in your current home"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "File for divorce",
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "You need to fill in a divorce petition form."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/divorce/file-for-divorce",
+                  "text": "How to start the divorce process"
+                },
+                {
+                  "href": "/divorce/grounds-for-divorce",
+                  "text": "Check the list of reasons why you can get a divorce"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=1115",
+                  "text": "Fill in the divorce petition form"
+                },
+                {
+                  "href": "/divorce/file-for-divorce",
+                  "text": "Pay the court fee",
+                  "context": "£550"
+                },
+                {
+                  "href": "/get-help-with-court-fees",
+                  "text": "Get help with court fees"
+                },
+                {
+                  "href": "https://courttribunalfinder.service.gov.uk/search/postcode?aol=Divorce&spoe=start",
+                  "text": "Send copies of the form to your nearest divorce centre"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "text": "Your husband or wife will receive a copy of the divorce petition. You'll be told when they respond and what you'll need to do next."
+            },
+            {
+              "type": "paragraph",
+              "text": "You might need to get legal advice if your husband or wife disagrees with your divorce petition."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/find-a-legal-adviser",
+                  "text": "Get legal advice"
+                }
+              ]
+            },
+            {
+              "type": "substep",
+              "optional": true
+            },
+            {
+              "type": "list",
+              "contents": [
+                {
+                  "href": "/divorce-missing-husband-wife",
+                  "text": "Find your husband or wife’s address",
+                  "context": "£0 to £100"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=1112",
+                  "text": "Apply to skip the divorce petition if you can’t find their address",
+                  "context": "£50"
+                },
+                {
+                  "href": "/divorce/if-your-husband-or-wife-lacks-mental-capacity",
+                  "text": "Get help if your husband or wife can’t make decisions for themselves"
+                },
+                {
+                  "href": "/divorce-missing-husband-wife",
+                  "text": "End the marriage because you think your husband or wife is dead",
+                  "context": "£365"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Send the court more details about your divorce",
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "If the court agrees with your divorce petition, you can apply for a document called a 'decree nisi'. You can give more information about why the marriage has broken down."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/divorce/apply-for-decree-nisi",
+                  "text": "Why you need a decree nisi"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=154",
+                  "text": "Fill in the application form"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "text": "You need to say why you're getting a divorce. Choose the form that matches what you put in the divorce petition:"
+            },
+            {
+              "type": "list",
+              "style": "choice",
+              "contents": [
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=144",
+                  "text": "unreasonable behaviour"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=142",
+                  "text": "adultery"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=146",
+                  "text": "desertion"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=149",
+                  "text": "2 years' separation"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=150",
+                  "text": "5 years' separation"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "text": "Send the forms to the court. "
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Finalise your divorce",
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "Once you, your husband or wife, and the court all agree, you can apply for the final document to end your marriage. This is called a 'decree absolute'. You can do this 6 weeks to 12 months after you receive the decree nisi."
+            },
+            {
+              "type": "paragraph",
+              "text": "If you want a legally-binding arrangement for dividing money and property you must apply to the court for this before you apply for a decree absolute."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/divorce/apply-for-a-decree-absolute",
+                  "text": "Why you need a decree absolute"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=1114",
+                  "text": "Fill in the decree absolute application form"
+                }
+
+              ]
+            },
+            {
+              "type": "paragraph",
+              "text": "Send the forms to the court. Once it's approved, they'll send you both a copy of the decree absolute and your divorce will be complete."
+            }
+
+          ]
+        }
+      ]
+    ]
+  }
+}

--- a/config/tasklists/get-a-divorce.json
+++ b/config/tasklists/get-a-divorce.json
@@ -20,22 +20,6 @@
   },
   "ab_test_prefix": "GetADivorce",
   "related_paths": [
-    "/stay-in-home-during-separation-or-divorce",
-    "/copy-decree-absolute-final-order",
-    "/visas-when-you-separate-or-divorce",
-    "/contact-grandchild-parents-divorce-separate",
-    "/government/publications/application-for-a-state-pension-forecast-on-divorce-or-dissolution-br20",
-    "/government/publications/family-law-the-ground-for-divorce",
-    "/government/publications/get-a-copy-of-a-domestic-violence-protection-notice--2",
-    "/how-to-annul-marriage",
-    "/marriage-allowance/if-your-circumstances-change",
-    "/changing-passport-information/divorce-or-returning-to-a-previous-surname",
-    "/make-will/updating-your-will",
-    "/marriage-allowance/if-your-circumstances-change",
-    "/marriage-allowance/how-to-apply",
-    "/make-will",
-    "/make-will/writing-your-will",
-    "/make-will/make-sure-your-will-is-legal",
     "/divorce/respond-to-a-divorce-petition"
   ],
   "tasklist": {

--- a/config/tasklists/get-a-divorce.json
+++ b/config/tasklists/get-a-divorce.json
@@ -184,7 +184,7 @@
                   "text": "Get help with court fees"
                 },
                 {
-                  "href": "https://courttribunalfinder.service.gov.uk/search/postcode?aol=Divorce&spoe=start",
+                  "href": "https://courttribunalfinder.service.gov.uk/search/postcode?aol=Divorce&amp;spoe=start",
                   "text": "Send copies of the form to your nearest divorce centre"
                 }
               ]

--- a/config/tasklists/learn-to-drive-a-car.json
+++ b/config/tasklists/learn-to-drive-a-car.json
@@ -1,0 +1,262 @@
+{
+  "title": "Learn to drive a car: step by step",
+  "base_path": "/learn-to-drive-a-car",
+  "description": "<p>Check what you need to do to learn to drive.</p>",
+  "links": {
+    "breadcrumbs": [
+      { "title": "Home", "url": "/" },
+      { "title": "Driving and transport", "url": "/browse/driving"},
+      { "title": "Learning to drive", "url": "/browse/driving/learning-to-drive"}
+    ]
+  },
+  "ab_test_prefix": "",
+  "related_paths": [
+    "/apply-for-your-full-driving-licence",
+    "/automatic-driving-licence-to-manual",
+    "/complain-about-a-driving-instructor",
+    "/driving-licence-fees",
+    "/driving-test-cost",
+    "/dvlaforms",
+    "/find-theory-test-pass-number",
+    "/government/publications/application-for-refunding-out-of-pocket-expenses",
+    "/government/publications/drivers-record-for-learner-drivers",
+    "/government/publications/driving-instructor-grades-explained",
+    "/government/publications/know-your-traffic-signs",
+    "/government/publications/l-plate-size-rules",
+    "/guidance/rules-for-observing-driving-tests",
+    "/report-an-illegal-driving-instructor",
+    "/report-driving-medical-condition",
+    "/report-driving-test-impersonation",
+    "/seat-belts-law",
+    "/speed-limits",
+    "/track-your-driving-licence-application",
+    "/vehicle-insurance",
+    "/driving-lessons-learning-to-drive/practising-with-family-or-friends",
+    "/driving-lessons-learning-to-drive/taking-driving-lessons",
+    "/driving-lessons-learning-to-drive/using-l-and-p-plates",
+    "/driving-test",
+    "/driving-test/changes-december-2017",
+    "/driving-test/disability-health-condition-or-learning-difficulty",
+    "/driving-test/driving-test-faults-result",
+    "/driving-test/test-cancelled-bad-weather",
+    "/driving-test/using-your-own-car",
+    "/driving-test/what-happens-during-test",
+    "/pass-plus/apply-for-a-pass-plus-certificate",
+    "/pass-plus/booking-pass-plus",
+    "/pass-plus/car-insurance-discounts",
+    "/pass-plus/local-councils-offering-discounts",
+    "/pass-plus/how-pass-plus-training-works",
+    "/theory-test",
+    "/theory-test/hazard-perception-test",
+    "/theory-test/if-you-have-safe-road-user-award",
+    "/theory-test/multiple-choice-questions",
+    "/theory-test/pass-mark-and-result",
+    "/theory-test/reading-difficulty-disability-or-health-condition"
+  ],
+  "tasklist": {
+    "groups": [
+      [
+        {
+          "title": "Check you're allowed to drive",
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "Most people can start learning to drive when they’re 17."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/vehicles-can-drive",
+                  "text": "Check what age you can drive"
+                },
+                {
+                  "href": "/legal-obligations-drivers-riders",
+                  "text": "Requirements for driving legally"
+                },
+                {
+                  "href": "/driving-eyesight-rules",
+                  "text": "Driving eyesight rules"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Get a provisional driving licence",
+          "contents": [
+            {
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/apply-first-provisional-driving-licence",
+                  "text": "Apply for your first provisional driving licence"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Driving lessons and practice",
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "You need a provisional driving licence to take lessons or practice."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/guidance/the-highway-code",
+                  "text": "The Highway Code"
+                },
+                {
+                  "href": "/driving-lessons-learning-to-drive",
+                  "text": "Taking driving lessons"
+                },
+                {
+                  "href": "/find-driving-schools-and-lessons",
+                  "text": "Find driving schools, lessons and instructors"
+                },
+                {
+                  "href": "/government/publications/car-show-me-tell-me-vehicle-safety-questions",
+                  "text": "Practise vehicle safety questions"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "Prepare for your theory test",
+          "contents": [
+            {
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/theory-test/revision-and-practice",
+                  "text": "Theory test revision and practice"
+                },
+                {
+                  "href": "/take-practice-theory-test",
+                  "text": "Take a practice theory test"
+                },
+                {
+                  "href": "https://www.safedrivingforlife.info/shop/product/official-dvsa-theory-test-kit-app-app",
+                  "text": "Theory and hazard perception test app"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Book and manage your theory test",
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "You need a provisional driving licence to book your theory test."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/book-theory-test",
+                  "text": "Book your theory test"
+                },
+                {
+                  "href": "/theory-test/what-to-take",
+                  "text": "What to take to your test"
+                },
+                {
+                  "href": "/change-theory-test",
+                  "text": "Change your theory test appointment"
+                },
+                {
+                  "href": "/check-theory-test",
+                  "text": "Check your theory test appointment details"
+                },
+                {
+                  "href": "/cancel-theory-test",
+                  "text": "Cancel your theory test"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Book and manage your driving test",
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "You must pass your theory test before you can book your driving test."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/book-driving-test",
+                  "text": "Book your driving test"
+                },
+                {
+                  "href": "/driving-test/what-to-take",
+                  "text": "What to take to your test"
+                },
+                {
+                  "href": "/change-driving-test",
+                  "text": "Change your driving test appointment"
+                },
+                {
+                  "href": "/check-driving-test",
+                  "text": "Check your driving test appointment details"
+                },
+                {
+                  "href": "/cancel-driving-test",
+                  "text": "Cancel your driving test"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "When you pass",
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "You can start driving as soon as you pass your driving test."
+            },
+            {
+              "type": "paragraph",
+              "text": "You must have an insurance policy that allows you to drive without supervision."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/pass-plus",
+                  "text": "Find out about Pass Plus training courses"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    ]
+  }
+}

--- a/govuk_navigation_helpers.gemspec
+++ b/govuk_navigation_helpers.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "gds-api-adapters", ">= 43.0"
+  spec.add_runtime_dependency 'govuk_ab_testing', '~> 2.4'
+  spec.add_runtime_dependency 'activesupport', '~> 5.1'
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/govuk_navigation_helpers.rb
+++ b/lib/govuk_navigation_helpers.rb
@@ -1,11 +1,20 @@
-require "govuk_navigation_helpers/version"
-require "govuk_navigation_helpers/breadcrumbs"
-require "govuk_navigation_helpers/related_items"
-require "govuk_navigation_helpers/taxon_breadcrumbs"
-require "govuk_navigation_helpers/taxonomy_sidebar"
-require "govuk_navigation_helpers/related_navigation_sidebar"
-require "govuk_navigation_helpers/rummager_taxonomy_sidebar_links"
-require "govuk_navigation_helpers/curated_taxonomy_sidebar_links"
+require 'active_support'
+require 'active_support/core_ext/hash/keys'
+require 'active_support/core_ext/object/blank'
+
+require 'govuk_ab_testing'
+
+require_relative "govuk_navigation_helpers/version"
+require_relative "govuk_navigation_helpers/breadcrumbs"
+require_relative "govuk_navigation_helpers/related_items"
+require_relative "govuk_navigation_helpers/taxon_breadcrumbs"
+require_relative "govuk_navigation_helpers/taxonomy_sidebar"
+require_relative "govuk_navigation_helpers/related_navigation_sidebar"
+require_relative "govuk_navigation_helpers/rummager_taxonomy_sidebar_links"
+require_relative "govuk_navigation_helpers/curated_taxonomy_sidebar_links"
+
+require_relative "govuk_navigation_helpers/tasklist_content"
+require_relative "govuk_navigation_helpers/current_tasklist_ab_test"
 
 module GovukNavigationHelpers
   class NavigationHelper

--- a/lib/govuk_navigation_helpers/current_tasklist_ab_test.rb
+++ b/lib/govuk_navigation_helpers/current_tasklist_ab_test.rb
@@ -40,12 +40,10 @@ module GovukNavigationHelpers
 
     def show_tasklist_sidebar?
       sidebar_variant.variant?('B')
-      true
     end
 
     def show_tasklist_header?
       header_variant.variant?('B')
-      true
     end
 
     def set_response_header(response)

--- a/lib/govuk_navigation_helpers/current_tasklist_ab_test.rb
+++ b/lib/govuk_navigation_helpers/current_tasklist_ab_test.rb
@@ -1,0 +1,70 @@
+module GovukNavigationHelpers
+  class CurrentTasklistAbTest
+    TASKLIST_HEADER_DIMENSION = 44
+    TASKLIST_SIDEBAR_DIMENSION = 66
+    PUBLICATION_PAGE = "/government/publications/car-show-me-tell-me-vehicle-safety-questions".freeze
+
+    def initialize(current_tasklist:, request:)
+      @current_tasklist = current_tasklist
+      @ab_test_prefix = current_tasklist.ab_test_prefix if current_tasklist
+      @request = request
+    end
+
+    def eligible?
+      !! current_tasklist
+    end
+
+    def header
+      @header ||= set_ab_test(
+        name: "#{ab_test_prefix}TaskListHeader",
+        dimension: TASKLIST_HEADER_DIMENSION
+      )
+    end
+
+    def sidebar
+      @sidebar ||= set_ab_test(
+        name: "#{ab_test_prefix}TaskListSidebar",
+        dimension: TASKLIST_SIDEBAR_DIMENSION
+      )
+    end
+
+    def sidebar_variant
+      @sidebar_variant ||=
+        sidebar.requested_variant(request.headers)
+    end
+
+    def header_variant
+      @header_variant ||=
+        header.requested_variant(request.headers)
+    end
+
+    def show_tasklist_sidebar?
+      sidebar_variant.variant?('B')
+    end
+
+    def show_tasklist_header?
+      header_variant.variant?('B')
+    end
+
+    def set_response_header(response)
+      sidebar_variant.configure_response(response) if show_tasklist_sidebar?
+      header_variant.configure_response(response) if show_tasklist_header?
+    end
+
+    def publication_with_sidebar?
+      show_tasklist_sidebar? && request.path == PUBLICATION_PAGE
+    end
+
+    def publication_with_sidebar_template_name
+      "publication_with_tasklist_sidebar"
+    end
+
+  private
+
+    attr_reader :current_tasklist, :ab_test_prefix, :request
+
+    def set_ab_test(name:, dimension:)
+      GovukAbTesting::AbTest.new(name, dimension: dimension)
+    end
+  end
+end

--- a/lib/govuk_navigation_helpers/current_tasklist_ab_test.rb
+++ b/lib/govuk_navigation_helpers/current_tasklist_ab_test.rb
@@ -40,10 +40,12 @@ module GovukNavigationHelpers
 
     def show_tasklist_sidebar?
       sidebar_variant.variant?('B')
+      true
     end
 
     def show_tasklist_header?
       header_variant.variant?('B')
+      true
     end
 
     def set_response_header(response)

--- a/lib/govuk_navigation_helpers/tasklist_content.rb
+++ b/lib/govuk_navigation_helpers/tasklist_content.rb
@@ -85,6 +85,7 @@ module GovukNavigationHelpers
               if link[:href] == path
                 link[:active] = true
                 tasklist[:show_step] = counter
+                tasklist[:highlight_group] = counter
                 return tasklist
               end
             end

--- a/lib/govuk_navigation_helpers/tasklist_content.rb
+++ b/lib/govuk_navigation_helpers/tasklist_content.rb
@@ -74,7 +74,7 @@ module GovukNavigationHelpers
     def set_task_as_active_if_current_page
       counter = 0
 
-      groups.each do |grouped_steps|
+      groups.each_with_index.each do |grouped_steps, group_index|
         grouped_steps.each do |step|
           counter += 1
 
@@ -85,7 +85,7 @@ module GovukNavigationHelpers
               if link[:href] == path
                 link[:active] = true
                 tasklist[:show_step] = counter
-                tasklist[:highlight_group] = counter
+                tasklist[:highlight_group] = group_index + 1
                 return tasklist
               end
             end

--- a/lib/govuk_navigation_helpers/tasklist_content.rb
+++ b/lib/govuk_navigation_helpers/tasklist_content.rb
@@ -1,0 +1,119 @@
+module GovukNavigationHelpers
+  class TasklistContent
+    TASKLIST_NAMES = %w(
+      get-a-divorce
+      end-a-civil-partnership
+      learn-to-drive-a-car
+    ).freeze
+
+    def self.current_tasklist(path)
+      TASKLIST_NAMES.each do |tasklist_name|
+        tasklist = new(file_name: tasklist_name, path: path)
+        return tasklist if tasklist.current?
+      end
+      nil
+    end
+
+    def initialize(file_name: nil, path: nil)
+      @file_name = file_name
+      @path = path
+    end
+
+    def title
+      parsed_file.dig(:title)
+    end
+
+    def base_path
+      parsed_file.dig(:base_path)
+    end
+
+    def tasklist
+      parsed_file.dig(:tasklist)
+    end
+
+    def ab_test_prefix
+      parsed_file.dig(:ab_test_prefix)
+    end
+
+    def skip_link
+      "##{groups.flatten.first[:title].downcase.tr(' ', '-')}"
+    end
+
+    def primary_paths
+      primary_content.map { |content|
+        content[:href] unless content[:href].start_with?('http')
+      }.select(&:present?)
+    end
+
+    def groups
+      tasklist.dig(:groups)
+    end
+
+    def related_paths
+      parsed_file.dig(:related_paths)
+    end
+
+    def set_current_task
+      set_task_as_active_if_current_page
+    end
+
+    def is_page_included_in_ab_test?
+      primary_paths.include?(path) ||
+        related_paths.include?(path)
+    end
+
+    def current?
+      primary_paths.include?(path) ||
+        related_paths.include?(path)
+    end
+
+  private
+
+    attr_reader :file_name, :file, :path
+
+    def set_task_as_active_if_current_page
+      counter = 0
+
+      groups.each do |grouped_steps|
+        grouped_steps.each do |step|
+          counter += 1
+
+          step[:contents].each do |content|
+            next unless content[:contents]
+
+            content[:contents].each do |link|
+              if link[:href] == path
+                link[:active] = true
+                tasklist[:show_step] = counter
+                return tasklist
+              end
+            end
+          end
+        end
+      end
+
+      tasklist
+    end
+
+    def primary_content
+      primary_content = groups.flat_map do |grouped_steps|
+        grouped_steps.flat_map do |group|
+          group[:contents].select { |content| content[:contents] }
+        end
+      end
+
+      primary_content.flat_map { |hash| hash[:contents] }
+    end
+
+    def parsed_file
+      @parsed_file ||=
+        JSON.parse(
+          File.read(
+            File.join(File.dirname(__FILE__), "../../", "config", "tasklists", "#{file_name}.json")
+          )
+        ).deep_symbolize_keys.tap do |json_file|
+          json_file[:tasklist].merge!(small: true, heading_level: 3)
+        end
+    end
+  end
+end

--- a/spec/tasklist_content_spec.rb
+++ b/spec/tasklist_content_spec.rb
@@ -17,8 +17,8 @@ module GovukNavigationHelpers
           end
         end
 
-        context 'when the path is /make-will' do
-          let(:path) { '/make-will' }
+        context 'when the path is /divorce/respond-to-a-divorce-petition' do
+          let(:path) { '/divorce/respond-to-a-divorce-petition' }
 
           it 'returns "Get Divorce" tasklist' do
             current_tasklist = described_class.current_tasklist(path)
@@ -251,22 +251,6 @@ module GovukNavigationHelpers
 
       it 'has related paths' do
         related_paths = %w(
-          /stay-in-home-during-separation-or-divorce
-          /copy-decree-absolute-final-order
-          /visas-when-you-separate-or-divorce
-          /contact-grandchild-parents-divorce-separate
-          /government/publications/application-for-a-state-pension-forecast-on-divorce-or-dissolution-br20
-          /government/publications/family-law-the-ground-for-divorce
-          /government/publications/get-a-copy-of-a-domestic-violence-protection-notice--2
-          /how-to-annul-marriage
-          /marriage-allowance/if-your-circumstances-change
-          /changing-passport-information/divorce-or-returning-to-a-previous-surname
-          /make-will/updating-your-will
-          /marriage-allowance/if-your-circumstances-change
-          /marriage-allowance/how-to-apply
-          /make-will
-          /make-will/writing-your-will
-          /make-will/make-sure-your-will-is-legal
           /divorce/respond-to-a-divorce-petition
         ).sort
 

--- a/spec/tasklist_content_spec.rb
+++ b/spec/tasklist_content_spec.rb
@@ -1,0 +1,285 @@
+require 'spec_helper'
+
+module GovukNavigationHelpers
+  RSpec.describe TasklistContent do
+    let(:path) { '/pass-plus' }
+    let(:tasklist_content) { described_class.new(file_name: "learn-to-drive-a-car", path: path) }
+
+    context '.current_tasklist' do
+      context 'based on the request' do
+        context 'when the path is /pass-plus' do
+          it 'returns "Learn to Drive" tasklist' do
+            current_tasklist = described_class.current_tasklist(path)
+
+            expect(
+              current_tasklist.title
+            ).to eql('Learn to drive a car: step by step')
+          end
+        end
+
+        context 'when the path is /make-will' do
+          let(:path) { '/make-will' }
+
+          it 'returns "Get Divorce" tasklist' do
+            current_tasklist = described_class.current_tasklist(path)
+
+            expect(
+              current_tasklist.title
+            ).to eql('Get a divorce: step by step')
+          end
+        end
+
+        context 'when the path is /end-civil-partnership' do
+          let(:path) { '/end-civil-partnership' }
+
+          it 'returns "End Civil Partnership" tasklist' do
+            current_tasklist = described_class.current_tasklist(path)
+
+            expect(
+              current_tasklist.title
+            ).to eql('End a civil partnership: step by step')
+          end
+        end
+
+        context 'when the path is in "Get Divorce" and "End Civil Partnership"' do
+          let(:path) { '/money-property-when-relationship-ends' }
+
+          it 'returns "Get Divorce" tasklist by default' do
+            current_tasklist = described_class.current_tasklist(path)
+
+            expect(
+              current_tasklist.title
+            ).to eql('Get a divorce: step by step')
+          end
+        end
+      end
+    end
+
+    context '#is_page_included_in_ab_test?' do
+      context 'when the requested path is part of the current tasklist' do
+        it 'returns true' do
+          expect(
+            tasklist_content.is_page_included_in_ab_test?
+          ).to be true
+        end
+      end
+
+      context 'when the requested path is not part of the current tasklist' do
+        let(:path) { '/pink-plus' }
+
+        it 'returns false' do
+          expect(
+            tasklist_content.is_page_included_in_ab_test?
+          ).to be false
+        end
+      end
+    end
+
+    context '#set_current_task' do
+      it 'sets /pass-plus as active' do
+        tasklist_content.set_current_task
+
+        expect(
+          tasklist_content.groups.last[0][:contents].last[:contents][0][:href]
+        ).to eql('/pass-plus')
+
+        expect(
+          tasklist_content.tasklist[:show_step]
+        ).to eql(7)
+
+        expect(
+          tasklist_content.groups.last[0][:contents].last[:contents][0][:active]
+        ).to be true
+      end
+    end
+
+    context "learning to drive a car tasklist content" do
+      it "has symbolized keys" do
+        tasklist_content.tasklist.keys.each do |key|
+          expect(key.is_a?(Symbol)).to be true
+        end
+      end
+
+      it "has a title" do
+        expect(tasklist_content.title).to eql("Learn to drive a car: step by step")
+      end
+
+      it "has a base_path" do
+        expect(tasklist_content.base_path).to eql("/learn-to-drive-a-car")
+      end
+
+      it "configures a sidebar" do
+        expect(tasklist_content.tasklist[:heading_level]).to eql(3)
+        expect(tasklist_content.tasklist[:small]).to be true
+      end
+
+      it "has a link in the correct structure" do
+        first_link = tasklist_content.tasklist[:groups][0][0][:contents][1][:contents][0]
+        expect(first_link[:href]).to eql("/vehicles-can-drive")
+        expect(first_link[:text]).to eql("Check what age you can drive")
+      end
+
+      it 'has all the primary paths' do
+        primary_paths = %w(
+          /apply-first-provisional-driving-licence
+          /book-driving-test
+          /book-theory-test
+          /cancel-driving-test
+          /cancel-theory-test
+          /change-driving-test
+          /change-theory-test
+          /check-driving-test
+          /check-theory-test
+          /driving-eyesight-rules
+          /driving-lessons-learning-to-drive
+          /driving-test/what-to-take
+          /find-driving-schools-and-lessons
+          /government/publications/car-show-me-tell-me-vehicle-safety-questions
+          /guidance/the-highway-code
+          /legal-obligations-drivers-riders
+          /pass-plus
+          /take-practice-theory-test
+          /theory-test/revision-and-practice
+          /theory-test/what-to-take
+          /vehicles-can-drive
+        ).sort
+
+        expect(
+          tasklist_content.primary_paths.sort
+        ).to match_array(primary_paths)
+      end
+
+      it 'has related paths' do
+        related_paths = %w(
+          /apply-for-your-full-driving-licence
+          /automatic-driving-licence-to-manual
+          /complain-about-a-driving-instructor
+          /driving-licence-fees
+          /driving-test-cost
+          /dvlaforms
+          /find-theory-test-pass-number
+          /government/publications/application-for-refunding-out-of-pocket-expenses
+          /government/publications/drivers-record-for-learner-drivers
+          /government/publications/driving-instructor-grades-explained
+          /government/publications/know-your-traffic-signs
+          /government/publications/l-plate-size-rules
+          /guidance/rules-for-observing-driving-tests
+          /report-an-illegal-driving-instructor
+          /report-driving-medical-condition
+          /report-driving-test-impersonation
+          /seat-belts-law
+          /speed-limits
+          /track-your-driving-licence-application
+          /vehicle-insurance
+          /driving-lessons-learning-to-drive/practising-with-family-or-friends
+          /driving-lessons-learning-to-drive/taking-driving-lessons
+          /driving-lessons-learning-to-drive/using-l-and-p-plates
+          /driving-test
+          /driving-test/changes-december-2017
+          /driving-test/disability-health-condition-or-learning-difficulty
+          /driving-test/driving-test-faults-result
+          /driving-test/test-cancelled-bad-weather
+          /driving-test/using-your-own-car
+          /driving-test/what-happens-during-test
+          /pass-plus/apply-for-a-pass-plus-certificate
+          /pass-plus/booking-pass-plus
+          /pass-plus/car-insurance-discounts
+          /pass-plus/local-councils-offering-discounts
+          /pass-plus/how-pass-plus-training-works
+          /theory-test
+          /theory-test/hazard-perception-test
+          /theory-test/if-you-have-safe-road-user-award
+          /theory-test/multiple-choice-questions
+          /theory-test/pass-mark-and-result
+          /theory-test/reading-difficulty-disability-or-health-condition
+        ).sort
+
+        expect(
+          tasklist_content.related_paths.sort
+        ).to match_array(related_paths)
+      end
+    end
+
+    context "get a divorce tasklist content" do
+      let(:tasklist_content) { described_class.new(file_name: "get-a-divorce", path: path) }
+
+      it "has symbolized keys" do
+        tasklist_content.tasklist.keys.each do |key|
+          expect(key.is_a?(Symbol)).to be true
+        end
+      end
+
+      it "has a title" do
+        expect(tasklist_content.title).to eql("Get a divorce: step by step")
+      end
+
+      it "has a base_path" do
+        expect(tasklist_content.base_path).to eql("/get-a-divorce")
+      end
+
+      it "configures a sidebar" do
+        expect(tasklist_content.tasklist[:heading_level]).to eql(3)
+        expect(tasklist_content.tasklist[:small]).to be true
+      end
+
+      it 'has all the primary paths' do
+        primary_paths = %w(
+          /divorce
+          /looking-after-children-divorce
+          /money-property-when-relationship-ends
+          /benefits-calculators
+          /report-benefits-change-circumstances
+          /contact-pension-service
+          /visas-when-you-separate-or-divorce
+          /stay-in-home-during-separation-or-divorce
+          /divorce/file-for-divorce
+          /divorce/grounds-for-divorce
+          /get-help-with-court-fees
+          /find-a-legal-adviser
+          /divorce-missing-husband-wife
+          /divorce/if-your-husband-or-wife-lacks-mental-capacity
+          /divorce/apply-for-decree-nisi
+          /divorce/apply-for-a-decree-absolute
+        ).sort
+
+        # there are two primary paths twice in the JSON structure
+        # that's legit.
+        expect(
+          tasklist_content.primary_paths.sort.uniq
+        ).to match_array(primary_paths)
+      end
+
+      it 'has related paths' do
+        related_paths = %w(
+          /stay-in-home-during-separation-or-divorce
+          /copy-decree-absolute-final-order
+          /visas-when-you-separate-or-divorce
+          /contact-grandchild-parents-divorce-separate
+          /government/publications/application-for-a-state-pension-forecast-on-divorce-or-dissolution-br20
+          /government/publications/family-law-the-ground-for-divorce
+          /government/publications/get-a-copy-of-a-domestic-violence-protection-notice--2
+          /how-to-annul-marriage
+          /marriage-allowance/if-your-circumstances-change
+          /changing-passport-information/divorce-or-returning-to-a-previous-surname
+          /make-will/updating-your-will
+          /marriage-allowance/if-your-circumstances-change
+          /marriage-allowance/how-to-apply
+          /make-will
+          /make-will/writing-your-will
+          /make-will/make-sure-your-will-is-legal
+          /divorce/respond-to-a-divorce-petition
+        ).sort
+
+        expect(
+          tasklist_content.related_paths.sort
+        ).to match_array(related_paths)
+      end
+
+      it "has a link in the correct structure" do
+        first_link = tasklist_content.tasklist[:groups][0][0][:contents][1][:contents][0]
+        expect(first_link[:href]).to eql("https://www.relate.org.uk/relationship-help/help-separation-and-divorce")
+        expect(first_link[:text]).to eql("Get advice from Relate")
+      end
+    end
+  end
+end


### PR DESCRIPTION
We moved the Tasklist functionality into GovukNavigationHelpers
so we can consolidate the code in one place.

It no longer uses `concerns` and instead the functionality is split in
two objects:

- TasklistContent: receives the current request.path and tries to find a
  tasklist that has that path, in case of one being used between "End
Civil Partnership" and "Get Divorce", "Get Divorce" tasklist is the
default.
- CurrentTasklistAbTest: Depends on having a current tasklist set to
  enable the AbTest and set it on the response headers.

- Added JSON files for "Learn to Drive a car", "Get Divorce" & "End a
  Civil Partnership", this are the structure necessary to render the
TasklistSidebar and TasklistHeader

This commit brings the TasklistContent functionality into a single place,
we have also added `govuk_ab_testing` as a runtime dependency as it's
necessary to continue our support to our current AB-Testing.

Trello: https://trello.com/c/JiPFogRf

# Examples from Government Frontend

This are examples of pages working with this changes

![screen shot 2017-12-08 at 10 55 10](https://user-images.githubusercontent.com/136777/33764549-b52ebd46-dc0c-11e7-9347-41e3e71cdeca.png)
![screen shot 2017-12-08 at 10 55 24](https://user-images.githubusercontent.com/136777/33764550-b54ada62-dc0c-11e7-9971-2d7e5533723b.png)
