### PR TITLE
Add topical events to related navigation

### DIFF
--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -105,6 +105,10 @@ module GovukNavigationHelpers
       filter_link_type(content_store_response.dig("links", "topics").to_a, "topic")
     end
 
+    def related_topical_events
+      filter_link_type(content_store_response.dig("links", "topical_events").to_a, "topical_event")
+    end
+
     def related_world_locations
       content_store_response.dig("links", "world_locations").to_a
     end

--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -113,6 +113,10 @@ module GovukNavigationHelpers
       content_store_response.dig("links", "world_locations").to_a
     end
 
+    def related_worldwide_organisations
+      filter_link_type(content_store_response.dig("links", "worldwide_organisations").to_a, "worldwide_organisation")
+    end
+
     def external_links
       content_store_response.dig("details", "external_related_links").to_a
     end

--- a/lib/govuk_navigation_helpers/related_navigation_sidebar.rb
+++ b/lib/govuk_navigation_helpers/related_navigation_sidebar.rb
@@ -12,6 +12,7 @@ module GovukNavigationHelpers
         related_items: related_items,
         collections: related_collections,
         topics: related_topics,
+        topical_events: related_topical_events,
         policies: related_policies,
         publishers: related_organisations,
         world_locations: related_world_locations,
@@ -60,6 +61,10 @@ module GovukNavigationHelpers
 
     def related_topics
       build_links_for_sidebar(@content_item.related_topics)
+    end
+
+    def related_topical_events
+      build_links_for_sidebar(@content_item.related_topical_events)
     end
 
     def related_contacts

--- a/lib/govuk_navigation_helpers/related_navigation_sidebar.rb
+++ b/lib/govuk_navigation_helpers/related_navigation_sidebar.rb
@@ -16,6 +16,7 @@ module GovukNavigationHelpers
         policies: related_policies,
         publishers: related_organisations,
         world_locations: related_world_locations,
+        worldwide_organisations: related_worldwide_organisations,
         other: [related_external_links, related_contacts]
       }
     end
@@ -49,6 +50,10 @@ module GovukNavigationHelpers
       locations = @content_item.related_world_locations
       locations.map! { |link| link.merge("base_path" => world_location_base_path(link["title"])) }
       build_links_for_sidebar(locations)
+    end
+
+    def related_worldwide_organisations
+      build_links_for_sidebar(@content_item.related_worldwide_organisations)
     end
 
     def related_collections

--- a/spec/navigation_sidebar_spec.rb
+++ b/spec/navigation_sidebar_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe GovukNavigationHelpers::RelatedNavigationSidebar do
         related_items: [],
         collections: [],
         topics: [],
+        topical_events: [],
         policies: [],
         publishers: [],
         world_locations: [],
@@ -75,6 +76,15 @@ RSpec.describe GovukNavigationHelpers::RelatedNavigationSidebar do
               "document_type" => "topic"
             }
           ],
+          "topical_events" => [
+            {
+              "content_id" => "32c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+              "locale" => "en",
+              "base_path" => "/related-topical-event",
+              "title" => "related topical event",
+              "document_type" => "topical_event"
+            }
+          ],
           "organisations" => [
             {
               "content_id" => "32c1b93d-2553-47c9-bc3c-fc5b513ecc32",
@@ -107,6 +117,7 @@ RSpec.describe GovukNavigationHelpers::RelatedNavigationSidebar do
         related_items: [{ path: "/related-item", text: "related item" }],
         collections: [{ path: "/related-collection", text: "related collection" }],
         topics: [{ path: "/related-topic", text: "related topic" }],
+        topical_events: [{ path: "/related-topical-event", text: "related topical event" }],
         policies: [{ path: "/related-policy", text: "related policy" }],
         publishers: [{ path: "/related-organisation", text: "related organisation" }],
         world_locations: [{ path: "/world/world-location/news", text: "World Location" }],

--- a/spec/related_navigation_sidebar_spec.rb
+++ b/spec/related_navigation_sidebar_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe GovukNavigationHelpers::RelatedNavigationSidebar do
         policies: [],
         publishers: [],
         world_locations: [],
+        worldwide_organisations: [],
         other: [[], []]
       }
 
@@ -121,9 +122,48 @@ RSpec.describe GovukNavigationHelpers::RelatedNavigationSidebar do
         policies: [{ path: "/related-policy", text: "related policy" }],
         publishers: [{ path: "/related-organisation", text: "related organisation" }],
         world_locations: [{ path: "/world/world-location/news", text: "World Location" }],
+        worldwide_organisations: [],
         other: [[], []]
       }
 
+      expect(payload).to eql(expected)
+    end
+
+    it "returns worldwide organisations" do
+      payload = payload_for("world_location_news_article",
+        "details" => {
+          "body" => "body",
+          "government" => {
+            "title" => "government",
+            "slug" => "government",
+            "current" => true
+          },
+          "political" => true,
+          "first_public_at" => "2016-01-01T19:00:00Z",
+        },
+        "links" => {
+          "worldwide_organisations" => [
+            {
+              "content_id" => "32c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+              "title" => "related worldwide organisation",
+              "base_path" => "/related-worldwide-organisation",
+              "document_type" => "worldwide_organisation",
+              "locale" => "en"
+            }
+          ],
+        }
+      )
+      expected = {
+        related_items: [],
+        collections: [],
+        topics: [],
+        topical_events: [],
+        policies: [],
+        publishers: [],
+        world_locations: [],
+        worldwide_organisations: [{ path: "/related-worldwide-organisation", text: "related worldwide organisation" }],
+        other: [[], []]
+      }
       expect(payload).to eql(expected)
     end
 


### PR DESCRIPTION
https://trello.com/c/iWa3b1Gd/164-navigation-sidebar-is-not-showing-topical-events

Navigation sidebar should also show Topical Events.