### PR TITLE
Bump version to 7.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.3.0
+
+* Update related navigation sidebar helper to return topical events and worldwide organisations.
+
 ## 7.2.0
 
 * Update related navigation sidebar helper to also return world location data

--- a/lib/govuk_navigation_helpers/version.rb
+++ b/lib/govuk_navigation_helpers/version.rb
@@ -1,3 +1,3 @@
 module GovukNavigationHelpers
-  VERSION = "7.2.0".freeze
+  VERSION = "7.3.0".freeze
 end


### PR DESCRIPTION
https://trello.com/c/iWa3b1Gd/164-navigation-sidebar-is-not-showing-topical-events

Adds topical events and worldwide orgs to related navigatio sidebar helper.