### PR TITLE
Tweak tasklist AB logic

### DIFF
--- a/lib/govuk_navigation_helpers/current_tasklist_ab_test.rb
+++ b/lib/govuk_navigation_helpers/current_tasklist_ab_test.rb
@@ -39,16 +39,20 @@ module GovukNavigationHelpers
     end
 
     def show_tasklist_sidebar?
-      sidebar_variant.variant?('B')
+      sidebar_variant.variant?('B') && is_tested_page?
     end
 
     def show_tasklist_header?
-      header_variant.variant?('B')
+      header_variant.variant?('B') && is_tested_page?
+    end
+
+    def is_tested_page?
+      return current_tasklist.is_page_included_in_ab_test? if current_tasklist
     end
 
     def set_response_header(response)
-      sidebar_variant.configure_response(response) if show_tasklist_sidebar?
-      header_variant.configure_response(response) if show_tasklist_header?
+      sidebar_variant.configure_response(response) if is_tested_page?
+      header_variant.configure_response(response) if is_tested_page?
     end
 
     def publication_with_sidebar?

--- a/spec/current_tasklist_ab_test_spec.rb
+++ b/spec/current_tasklist_ab_test_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+module GovukNavigationHelpers
+  RSpec.describe CurrentTasklistAbTest do
+    let(:tasklist) { TasklistContent.current_tasklist('/vehicles-can-drive') }
+
+    it "indicates when to show the task list components" do
+      request = double('request', headers: {
+        'HTTP_GOVUK_ABTEST_TASKLISTSIDEBAR' => 'B',
+        'HTTP_GOVUK_ABTEST_TASKLISTHEADER' => 'B'
+        })
+      ab_test = described_class.new(current_tasklist: tasklist, request: request)
+      expect(ab_test.show_tasklist_sidebar?).to be true
+      expect(ab_test.show_tasklist_header?).to be true
+    end
+
+    it "indicates when to not show the task list components" do
+      request = double('request', headers: {
+        'HTTP_GOVUK_ABTEST_TASKLISTSIDEBAR' => 'A',
+        'HTTP_GOVUK_ABTEST_TASKLISTHEADER' => 'A'
+        })
+      ab_test = described_class.new(current_tasklist: tasklist, request: request)
+      expect(ab_test.show_tasklist_sidebar?).to be false
+      expect(ab_test.show_tasklist_header?).to be false
+    end
+
+    it "copes with a mixture when to not show the task list components" do
+      request = double('request', headers: {
+        'HTTP_GOVUK_ABTEST_TASKLISTSIDEBAR' => 'B',
+        'HTTP_GOVUK_ABTEST_TASKLISTHEADER' => 'A'
+        })
+      ab_test = described_class.new(current_tasklist: tasklist, request: request)
+      expect(ab_test.show_tasklist_sidebar?).to be true
+      expect(ab_test.show_tasklist_header?).to be false
+    end
+
+    it "configures the response vary header correctly " do
+      request = double('request', headers: {
+        'HTTP_GOVUK_ABTEST_TASKLISTSIDEBAR' => 'A',
+        'HTTP_GOVUK_ABTEST_TASKLISTHEADER' => 'B'
+        })
+      response = double('response', headers: {})
+      ab_test = described_class.new(current_tasklist: tasklist, request: request)
+
+      ab_test.set_response_header(response)
+
+      expect(response.headers["Vary"]).to eq("GOVUK-ABTest-TaskListSidebar, GOVUK-ABTest-TaskListHeader")
+    end
+
+    it "configures the response vary header correctly when the page is not under test" do
+      request = double('request', headers: {
+        'HTTP_GOVUK_ABTEST_TASKLISTSIDEBAR' => 'A',
+        'HTTP_GOVUK_ABTEST_TASKLISTHEADER' => 'B'
+        })
+      response = double('response', headers: {})
+      tasklist = TasklistContent.current_tasklist("/not_under_test")
+      ab_test = described_class.new(current_tasklist: tasklist, request: request)
+
+      ab_test.set_response_header(response)
+
+      expect(response.headers["Vary"]).to be nil
+    end
+  end
+end


### PR DESCRIPTION
We want to display headers if the page is in the AB test whether or not the
sidebar is shown.

Also, we only want to show the sidebar if the page is in the test cohort.

Also, added some rudimentary tests to make sure we're calling the ab test component when we're supposed to.