### PR TITLE
Add statistical data sets to related navigation helper

### DIFF
--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -101,6 +101,10 @@ module GovukNavigationHelpers
       filter_link_type(content_store_response.dig("links", "related_policies").to_a, "policy")
     end
 
+    def related_statistical_data_sets
+      filter_link_type(content_store_response.dig("links", "related_statistical_data_sets").to_a, "statistical_data_set")
+    end
+
     def related_topics
       filter_link_type(content_store_response.dig("links", "topics").to_a, "topic")
     end

--- a/lib/govuk_navigation_helpers/related_navigation_sidebar.rb
+++ b/lib/govuk_navigation_helpers/related_navigation_sidebar.rb
@@ -11,6 +11,7 @@ module GovukNavigationHelpers
       {
         related_items: related_items,
         collections: related_collections,
+        statistical_data_sets: related_statistical_data_sets,
         topics: related_topics,
         topical_events: related_topical_events,
         policies: related_policies,
@@ -62,6 +63,10 @@ module GovukNavigationHelpers
 
     def related_policies
       build_links_for_sidebar(@content_item.related_policies)
+    end
+
+    def related_statistical_data_sets
+      build_links_for_sidebar(@content_item.related_statistical_data_sets)
     end
 
     def related_topics

--- a/spec/related_navigation_sidebar_spec.rb
+++ b/spec/related_navigation_sidebar_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe GovukNavigationHelpers::RelatedNavigationSidebar do
       expected = {
         related_items: [],
         collections: [],
+        statistical_data_sets: [],
         topics: [],
         topical_events: [],
         policies: [],
@@ -123,6 +124,7 @@ RSpec.describe GovukNavigationHelpers::RelatedNavigationSidebar do
         publishers: [{ path: "/related-organisation", text: "related organisation" }],
         world_locations: [{ path: "/world/world-location/news", text: "World Location" }],
         worldwide_organisations: [],
+        statistical_data_sets: [],
         other: [[], []]
       }
 
@@ -156,12 +158,53 @@ RSpec.describe GovukNavigationHelpers::RelatedNavigationSidebar do
       expected = {
         related_items: [],
         collections: [],
+        statistical_data_sets: [],
         topics: [],
         topical_events: [],
         policies: [],
         publishers: [],
         world_locations: [],
         worldwide_organisations: [{ path: "/related-worldwide-organisation", text: "related worldwide organisation" }],
+        other: [[], []]
+      }
+      expect(payload).to eql(expected)
+    end
+
+    it "returns statistical data sets" do
+      payload = payload_for("publication",
+        "details" => {
+          "body" => "body",
+          "government" => {
+            "title" => "government",
+            "slug" => "government",
+            "current" => true
+          },
+          "political" => false,
+          "documents" => [],
+          "first_public_at" => "2016-01-01T19:00:00Z",
+        },
+        "links" => {
+          "related_statistical_data_sets" => [
+            {
+              "content_id" => "32c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+              "title" => "related statistical data set",
+              "base_path" => "/related-statistical-data-set",
+              "document_type" => "statistical_data_set",
+              "locale" => "en"
+            }
+          ],
+        }
+      )
+      expected = {
+        related_items: [],
+        collections: [],
+        statistical_data_sets: [{ path: "/related-statistical-data-set", text: "related statistical data set" }],
+        topics: [],
+        topical_events: [],
+        policies: [],
+        publishers: [],
+        world_locations: [],
+        worldwide_organisations: [],
         other: [[], []]
       }
       expect(payload).to eql(expected)


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/2538570

Include statistical data sets in related navigation helper.