### PR TITLE
Parameterise world location links

### DIFF
--- a/lib/govuk_navigation_helpers/related_navigation_sidebar.rb
+++ b/lib/govuk_navigation_helpers/related_navigation_sidebar.rb
@@ -34,7 +34,7 @@ module GovukNavigationHelpers
     end
 
     def world_location_base_path(title)
-      "/world/#{title.downcase.tr(' ', '-')}/news"
+      "/world/#{parameterise(title)}/news"
     end
 
     def related_items
@@ -91,6 +91,18 @@ module GovukNavigationHelpers
         title: "Elsewhere on the web",
         links: build_links_for_sidebar(@content_item.external_links, "url", rel: 'external')
       ]
+    end
+
+    def parameterise(str, sep = "-")
+      parameterised_str = str.gsub(/[^\w\-]+/, sep)
+      unless sep.nil? || sep.empty?
+        re_sep = Regexp.escape(sep)
+        # No more than one of the separator in a row.
+        parameterised_str.gsub!(/#{re_sep}{2,}/, sep)
+        # Remove leading/trailing separator.
+        parameterised_str.gsub!(/^#{re_sep}|#{re_sep}$/, '')
+      end
+      parameterised_str.downcase
     end
   end
 end

--- a/spec/related_navigation_sidebar_spec.rb
+++ b/spec/related_navigation_sidebar_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe GovukNavigationHelpers::RelatedNavigationSidebar do
           "world_locations" => [
             {
               "content_id" => "32c1b93d-2553-47c9-bc3c-fc5b513ecc32",
-              "title" => "World Location",
+              "title" => "World, ~ (@Location)",
               "locale" => "en"
             }
           ],
@@ -122,7 +122,7 @@ RSpec.describe GovukNavigationHelpers::RelatedNavigationSidebar do
         topical_events: [{ path: "/related-topical-event", text: "related topical event" }],
         policies: [{ path: "/related-policy", text: "related policy" }],
         publishers: [{ path: "/related-organisation", text: "related organisation" }],
-        world_locations: [{ path: "/world/world-location/news", text: "World Location" }],
+        world_locations: [{ path: "/world/world-location/news", text: "World, ~ (@Location)" }],
         worldwide_organisations: [],
         statistical_data_sets: [],
         other: [[], []]


### PR DESCRIPTION
https://trello.com/c/1nhkSnqd/180-navigating-to-a-world-location-page-is-broken-from-the-sidebar

https://govuk.zendesk.com/agent/tickets/2539244

World location titles may contain non-alphanumeric characters
eg. `UK Mission to the United Nations, New York`
which need to be stripped while building the location slug for the location base path.
I've based the parameterize method on the [Rails implementation](https://apidock.com/rails/ActiveSupport/Inflector/parameterize) though
the i18n `transliterate` method isn't included as I don't believe it's necessary.