### PR TITLE
Return mainstream topics to related nav

### DIFF
--- a/lib/govuk_navigation_helpers/related_navigation_sidebar.rb
+++ b/lib/govuk_navigation_helpers/related_navigation_sidebar.rb
@@ -70,7 +70,9 @@ module GovukNavigationHelpers
     end
 
     def related_topics
-      build_links_for_sidebar(@content_item.related_topics)
+      topics = build_links_for_sidebar(@content_item.related_topics)
+      topics << related_mainstream_topic << related_mainstream_parent_topic
+      topics.compact
     end
 
     def related_topical_events
@@ -93,6 +95,16 @@ module GovukNavigationHelpers
       ]
     end
 
+    def related_mainstream_topic
+      return unless grouped.tagged_to_same_mainstream_browse_page.any?
+      { text: @content_item.parent.title, path: @content_item.parent.base_path }
+    end
+
+    def related_mainstream_parent_topic
+      return unless grouped.parents_tagged_to_same_mainstream_browse_page.any?
+      { text: @content_item.parent.parent.title, path: @content_item.parent.parent.base_path }
+    end
+
     def parameterise(str, sep = "-")
       parameterised_str = str.gsub(/[^\w\-]+/, sep)
       unless sep.nil? || sep.empty?
@@ -103,6 +115,10 @@ module GovukNavigationHelpers
         parameterised_str.gsub!(/^#{re_sep}|#{re_sep}$/, '')
       end
       parameterised_str.downcase
+    end
+
+    def grouped
+      @grouped ||= GroupedRelatedLinks.new(@content_item)
     end
   end
 end

--- a/spec/related_navigation_sidebar_spec.rb
+++ b/spec/related_navigation_sidebar_spec.rb
@@ -52,12 +52,30 @@ RSpec.describe GovukNavigationHelpers::RelatedNavigationSidebar do
           "delivered_on" => "2017-09-22T14:30:00+01:00"
         },
         "links" => {
+          "parent" => [
+            {
+              "content_id" => "32c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+              "locale" => "en",
+              "base_path" => "/mainstream-topic",
+              "title" => "mainstream topic"
+            }
+          ],
           "ordered_related_items" => [
             {
               "content_id" => "32c1b93d-2553-47c9-bc3c-fc5b513ecc32",
               "locale" => "en",
               "base_path" => "/related-item",
-              "title" => "related item"
+              "title" => "related item",
+              "links" => {
+                "mainstream_browse_pages" => [
+                  {
+                    "content_id" => "32c1b93d-2553-47c9-bc3c-fc5b513ecc32",
+                    "locale" => "en",
+                    "base_path" => "/mainstream-topic",
+                    "title" => "mainstream topic"
+                  }
+                ]
+              }
             }
           ],
           "document_collections" => [
@@ -118,7 +136,7 @@ RSpec.describe GovukNavigationHelpers::RelatedNavigationSidebar do
       expected = {
         related_items: [{ path: "/related-item", text: "related item" }],
         collections: [{ path: "/related-collection", text: "related collection" }],
-        topics: [{ path: "/related-topic", text: "related topic" }],
+        topics: [{ path: "/related-topic", text: "related topic" }, { path: "/mainstream-topic", text: "mainstream topic" }],
         topical_events: [{ path: "/related-topical-event", text: "related topical event" }],
         policies: [{ path: "/related-policy", text: "related policy" }],
         publishers: [{ path: "/related-organisation", text: "related organisation" }],


### PR DESCRIPTION
While moving over answer and help pages to the universal layout, we [noticed](https://github.com/alphagov/government-frontend/pull/649#issuecomment-354800476) that mainstream topics were not being displayed in the related navigation sidebar. We need to include this data in the data that is returned for the sidebar.
  