### PR TITLE
Bump version to 8.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 8.2.0
 * Update related navigation sidebar helper to return mainstream topics alongside whitehall topics
+* Update content in the /end-a-civil-partnership, /get-a-divorce tasklists
 
 ## 8.1.1
 * Update content in the /end-a-civil-partnership, /get-a-divorce, and /learn-to-drive-a-car tasklists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 8.2.0
+* Update related navigation sidebar helper to return mainstream topics alongside whitehall topics
+
 ## 8.1.1
 * Update content in the /end-a-civil-partnership, /get-a-divorce, and /learn-to-drive-a-car tasklists
 * Strip non-alphanumeric characters from world location links for related navigation helper.

--- a/lib/govuk_navigation_helpers/version.rb
+++ b/lib/govuk_navigation_helpers/version.rb
@@ -1,3 +1,3 @@
 module GovukNavigationHelpers
-  VERSION = "8.1.1".freeze
+  VERSION = "8.2.0".freeze
 end


### PR DESCRIPTION
Update related navigation sidebar helper to return mainstream topics alongside whitehall topics