### PR TITLE
Bump version to 8.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 8.2.1
+* Update related navigation sidebar helper to deduplicate mainstream topics with the same title as whithall topics.
+  Mainstream topics are preferred in the case of duplicates.
+* Update Yard dependency to 0.9.12
+
 ## 8.2.0
 * Update related navigation sidebar helper to return mainstream topics alongside whitehall topics
 * Update content in the /end-a-civil-partnership, /get-a-divorce tasklists

--- a/lib/govuk_navigation_helpers/version.rb
+++ b/lib/govuk_navigation_helpers/version.rb
@@ -1,3 +1,3 @@
 module GovukNavigationHelpers
-  VERSION = "8.2.0".freeze
+  VERSION = "8.2.1".freeze
 end


### PR DESCRIPTION
- Update related navigation sidebar helper to de-duplicate mainstream topics with the same title as Whitehall topics. Mainstream topics are preferred in the case of duplicates.