### PR TITLE
Select taxons with live phase 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+* Check if a taxon's phase is 'live' to determine if it should be passed to a navigation component to be displayed on a page.
+* Remove the old content_id whitelisting approach to filtering for taxons.
+
 ## 9.0.0
 * Task lists are now called "step by step navigation".  Things have been renamed to support this
 * The (now) step nav component has an updated data format.  Updated /learn-to-drive-a-car to support this

--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -38,9 +38,13 @@ module GovukNavigationHelpers
     def parent_taxons
       @_parent_taxons ||= begin
         taxon_links
-          .select { |t| descendent_from_whitelisted_root_taxon?(t) }
+          .select { |t| phase_is_live?(t) }
           .map { |taxon| ContentItem.new(taxon) }.sort_by(&:title)
       end
+    end
+
+    def phase_is_live?(taxon)
+      taxon["phase"] == "live"
     end
 
     def mainstream_browse_pages

--- a/lib/govuk_navigation_helpers/content_item.rb
+++ b/lib/govuk_navigation_helpers/content_item.rb
@@ -5,18 +5,6 @@ module GovukNavigationHelpers
   #
   # @private
   class ContentItem
-    WORLD_TAXON_CONTENT_ID = "91b8ef20-74e7-4552-880c-50e6d73c2ff9".freeze
-    EDUCATION_TAXON_CONTENT_ID = "c58fdadd-7743-46d6-9629-90bb3ccc4ef0".freeze
-    CHILDCARE_PARENTING_TAXON_CONTENT_ID = "206b7f3a-49b5-476f-af0f-fd27e2a68473".freeze
-
-    def self.whitelisted_root_taxon_content_ids
-      [
-        WORLD_TAXON_CONTENT_ID,
-        EDUCATION_TAXON_CONTENT_ID,
-        CHILDCARE_PARENTING_TAXON_CONTENT_ID,
-      ]
-    end
-
     attr_reader :content_store_response
 
     def initialize(content_store_response)
@@ -155,21 +143,6 @@ module GovukNavigationHelpers
       # whereas a Taxon content item's taxon links are stored in ["links"]["parent_taxons"]
       # so here we cater for both possibilities
       content_store_response.dig("links", "taxons") || content_store_response.dig("links", "parent_taxons") || []
-    end
-
-    def descendent_from_whitelisted_root_taxon?(taxon)
-      root_taxon = get_root_taxon(taxon)
-      ContentItem.whitelisted_root_taxon_content_ids.include?(root_taxon["content_id"])
-    end
-
-    def get_root_taxon(taxon)
-      parent_taxons = taxon.dig("links", "parent_taxons")
-
-      if parent_taxons.nil? || parent_taxons.empty?
-        taxon
-      else
-        get_root_taxon(parent_taxons.first)
-      end
     end
 
     def filter_link_type(links, type)

--- a/spec/content_item_spec.rb
+++ b/spec/content_item_spec.rb
@@ -1,19 +1,6 @@
 require "spec_helper"
 
 RSpec.describe GovukNavigationHelpers::ContentItem do
-  describe ".whitelisted_root_taxon_content_ids" do
-    it "returns the whitelisted content_ids" do
-      expected_content_ids = [
-        "91b8ef20-74e7-4552-880c-50e6d73c2ff9",
-        "c58fdadd-7743-46d6-9629-90bb3ccc4ef0",
-        "206b7f3a-49b5-476f-af0f-fd27e2a68473",
-      ]
-
-      content_ids = described_class.whitelisted_root_taxon_content_ids
-      expect(content_ids).to eq(expected_content_ids)
-    end
-  end
-
   describe "#parent_taxons" do
     context "for a content item with taxons links" do
       context "with a parent taxon with phase set to 'live'" do

--- a/spec/content_item_spec.rb
+++ b/spec/content_item_spec.rb
@@ -15,18 +15,13 @@ RSpec.describe GovukNavigationHelpers::ContentItem do
   end
 
   describe "#parent_taxons" do
-    before do
-      allow(described_class)
-        .to receive(:whitelisted_root_taxon_content_ids)
-        .and_return(["aaaa-bbbb"])
-    end
-
     context "for a content item with taxons links" do
-      context "with a whitelisted parent taxon" do
+      context "with a parent taxon with phase set to 'live'" do
         let(:taxon) do
           {
             "content_id" => "cccc-dddd",
             "title" => "Taxon",
+            "phase" => "live",
             "links" => {
               "parent_taxons" => [
                 {
@@ -54,11 +49,12 @@ RSpec.describe GovukNavigationHelpers::ContentItem do
         end
       end
 
-      context "with a non-whitelisted parent taxon" do
+      context "with a parent taxon with phase not set to 'live'" do
         let(:taxon) do
           {
             "content_id" => "cccc-dddd",
             "title" => "Taxon",
+            "phase" => "beta",
             "links" => {
               "parent_taxons" => [
                 {
@@ -116,11 +112,12 @@ RSpec.describe GovukNavigationHelpers::ContentItem do
     end
 
     context "for a taxon content item with parent taxon links" do
-      context "with a whitelisted parent taxon" do
+      context "with a parent taxon with phase set to 'live'" do
         let(:taxon) do
           {
             "content_id" => "cccc-dddd",
             "title" => "Taxon",
+            "phase" => "live",
             "links" => {
               "parent_taxons" => [
                 {
@@ -148,11 +145,12 @@ RSpec.describe GovukNavigationHelpers::ContentItem do
         end
       end
 
-      context "with a non-whitelisted parent taxon" do
+      context "with a parent taxon with phase not set to 'live'" do
         let(:taxon) do
           {
             "content_id" => "cccc-dddd",
             "title" => "Taxon",
+            "phase" => "beta",
             "links" => {
               "parent_taxons" => [
                 {

--- a/spec/taxon_breadcrumbs_spec.rb
+++ b/spec/taxon_breadcrumbs_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
           "base_path" => "/another-parent",
           "content_id" => "30c1b93d-2553-47c9-bc3c-fc5b513ecc32",
           "locale" => "en",
+          "phase" => "live",
         }
 
         parent = {
@@ -64,6 +65,7 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
           "locale" => "en",
           "title" => "A-parent",
           "base_path" => "/a-parent",
+          "phase" => "live",
           "links" => {
             "parent_taxons" => [grandparent]
           }
@@ -91,6 +93,7 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
           "locale" => "en",
           "title" => "A-parent",
           "base_path" => "/a-parent",
+          "phase" => "live",
           "links" => {
             "parent_taxons" => []
           }
@@ -116,6 +119,7 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
           "locale" => "en",
           "title" => "Parent A",
           "base_path" => "/parent-a",
+          "phase" => "live",
           "links" => {
             "parent_taxons" => []
           }
@@ -125,6 +129,7 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
           "locale" => "en",
           "title" => "Parent B",
           "base_path" => "/parent-b",
+          "phase" => "live",
           "links" => {
             "parent_taxons" => []
           }
@@ -174,6 +179,7 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
             "locale" => "en",
             "title" => "Taxon",
             "base_path" => "/taxon",
+            "phase" => "live",
             "links" => {
               "parent_taxons" => parents
             },

--- a/spec/taxon_breadcrumbs_spec.rb
+++ b/spec/taxon_breadcrumbs_spec.rb
@@ -2,12 +2,6 @@ require 'spec_helper'
 
 RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
   describe "Taxon breadcrumbs" do
-    before do
-      allow(GovukNavigationHelpers::ContentItem)
-        .to receive(:whitelisted_root_taxon_content_ids)
-        .and_return(['30c1b93d-2553-47c9-bc3c-fc5b513ecc32'])
-    end
-
     it "can handle any valid content item" do
       generator = GovukSchemas::RandomExample.for_schema(
         "taxon",

--- a/spec/taxonomy_sidebar_spec.rb
+++ b/spec/taxonomy_sidebar_spec.rb
@@ -6,12 +6,6 @@ include GdsApi::TestHelpers::Rummager
 
 RSpec.describe GovukNavigationHelpers::TaxonomySidebar do
   describe '#sidebar' do
-    before do
-      allow(GovukNavigationHelpers::ContentItem)
-        .to receive(:whitelisted_root_taxon_content_ids)
-        .and_return(['taxon-a', 'taxon-b', 'taxon-c'])
-    end
-
     it 'can handle any valid content item' do
       stub_any_rummager_search_to_return_no_results
 

--- a/spec/taxonomy_sidebar_spec.rb
+++ b/spec/taxonomy_sidebar_spec.rb
@@ -95,7 +95,8 @@ RSpec.describe GovukNavigationHelpers::TaxonomySidebar do
           "title" => "Taxon C",
           "base_path" => "/taxon-c",
           "content_id" => "taxon-c",
-          "description" => "The C taxon."
+          "description" => "The C taxon.",
+          "phase" => "live",
         }
 
         expect(sidebar_for(content_item)).to eq(
@@ -507,12 +508,14 @@ RSpec.describe GovukNavigationHelpers::TaxonomySidebar do
             "base_path" => "/taxon-b",
             "content_id" => "taxon-b",
             "description" => "The B taxon.",
+            "phase" => "live",
           },
           {
             "title" => "Taxon A",
             "base_path" => "/taxon-a",
             "content_id" => "taxon-a",
             "description" => "The A taxon.",
+            "phase" => "live",
           },
         ],
       },


### PR DESCRIPTION
For https://trello.com/c/cxPboFUb/285-update-sidebar-breadcrumbs-components-to-only-show-taxons-with-the-live-phase-this-replaces-the-current-whitelisting-taxon-metho

We don't want to display taxons whose phase is not 'live', so we update
`ContentItem` to check if a taxon's phase is 'live' when constructing parent
taxons.  This check replaced the old whitelisting approach, so code associated with this is removed in this PR.
