### PR TITLE
Bump version to 9.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 9.1.0 
 
 * Check if a taxon's phase is 'live' to determine if it should be passed to a navigation component to be displayed on a page.
 * Remove the old content_id whitelisting approach to filtering for taxons.

--- a/lib/govuk_navigation_helpers/version.rb
+++ b/lib/govuk_navigation_helpers/version.rb
@@ -1,3 +1,3 @@
 module GovukNavigationHelpers
-  VERSION = "9.0.0".freeze
+  VERSION = "9.1.0".freeze
 end


### PR DESCRIPTION
https://trello.com/c/cxPboFUb/285-update-sidebar-breadcrumbs-components-to-only-show-taxons-with-the-live-phase-this-replaces-the-current-whitelisting-taxon-metho 

## 9.1.0 
 
  * Check if a taxon's phase is 'live' to determine if it should be passed to a navigation component to be displayed on a page.
  * Remove the old content_id whitelisting approach to filtering for taxons.
