### PR TITLE
Bump to 9.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 9.2.0
 
 * Step by step navigation helpers have been removed from here.  They now live
 in govuk_publishing_components as they are closely coupled to components that

--- a/lib/govuk_navigation_helpers/version.rb
+++ b/lib/govuk_navigation_helpers/version.rb
@@ -1,3 +1,3 @@
 module GovukNavigationHelpers
-  VERSION = "9.1.0".freeze
+  VERSION = "9.2.0".freeze
 end


### PR DESCRIPTION
For https://trello.com/c/nGtzTPCu/283-update-government-frontend-to-use-relatednavigation-component