### PR TITLE
Return only parent taxons in taxon breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* No longer return the current page in taxon breadcrumbs.
+
 ## 9.2.0
 
 * Step by step navigation helpers have been removed from here.  They now live

--- a/lib/govuk_navigation_helpers/taxon_breadcrumbs.rb
+++ b/lib/govuk_navigation_helpers/taxon_breadcrumbs.rb
@@ -17,13 +17,10 @@ module GovukNavigationHelpers
         title: "Home",
         url: "/",
         is_page_parent: ordered_parents.empty?
-}
-
-      ordered_breadcrumbs = ordered_parents.reverse
-      ordered_breadcrumbs << { title: content_item.title, is_current_page: true }
+      }
 
       {
-        breadcrumbs: ordered_breadcrumbs
+        breadcrumbs: ordered_parents.reverse
       }
     end
 

--- a/spec/taxon_breadcrumbs_spec.rb
+++ b/spec/taxon_breadcrumbs_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
       expect(breadcrumbs).to eq(
         breadcrumbs: [
           { title: "Home", url: "/", is_page_parent: true },
-          { title: "Some Content", is_current_page: true }
         ]
       )
     end
@@ -39,7 +38,6 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
         breadcrumbs: [
           { title: "Home", url: "/", is_page_parent: false },
           { title: "Taxon", url: "/taxon", is_page_parent: true },
-          { title: "Some Content", is_current_page: true },
         ]
       )
     end
@@ -74,7 +72,6 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
             { title: "Another-parent", url: "/another-parent", is_page_parent: false },
             { title: "A-parent", url: "/a-parent", is_page_parent: false },
             { title: "Taxon", url: "/taxon", is_page_parent: true },
-            { title: "Some Content", is_current_page: true },
           ]
         )
       end
@@ -100,7 +97,6 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
           breadcrumbs: [
             { title: "Home", url: "/", is_page_parent: false },
             { title: "A-parent", url: "/a-parent", is_page_parent: true },
-            { title: "Taxon", is_current_page: true },
           ]
         )
       end
@@ -136,7 +132,6 @@ RSpec.describe GovukNavigationHelpers::TaxonBreadcrumbs do
           breadcrumbs: [
             { title: "Home", url: "/", is_page_parent: false },
             { title: "Parent A", url: "/parent-a", is_page_parent: true },
-            { title: "Taxon", is_current_page: true },
           ]
         )
       end


### PR DESCRIPTION
For https://trello.com/c/RCjHKJb8/125-only-show-the-parent-taxons-in-the-breadcrumbs

We don't want to show the current topic page title in taxon breadcrumbs, as
currently there is duplication between the breadcrumbs and the page header
title on pages that use taxon breadcrumbs.

## Example topic page
**Before**
<img width="655" alt="topic-page-before" src="https://user-images.githubusercontent.com/13434452/37519063-b16a6674-290f-11e8-9630-7b65d4f45297.png">

**After**
<img width="533" alt="topic-page-after" src="https://user-images.githubusercontent.com/13434452/37519076-bb41967c-290f-11e8-949c-3672bbf226b5.png">

## Example content page
**Before**
<img width="650" alt="content-page-before" src="https://user-images.githubusercontent.com/13434452/37519045-a68f4cf6-290f-11e8-99c2-f9145ab5031a.png">

**After**
<img width="666" alt="content-page-after" src="https://user-images.githubusercontent.com/13434452/37519057-ae438e30-290f-11e8-88cc-40afc3f620b7.png">